### PR TITLE
Fix blank page and styling issues in safari

### DIFF
--- a/iron-doc-element.css
+++ b/iron-doc-element.css
@@ -33,10 +33,13 @@ header {
 }
 
 #api {
+  display: -webkit-flex;
   display: flex;
+  -webkit-align-items: center;
   align-items: center;
 }
 #api header {
+  -webkit-flex: 1;
   flex: 1;
   padding-left: 16px;
 }

--- a/iron-doc-property.css
+++ b/iron-doc-property.css
@@ -60,12 +60,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 #details {
+  -webkit-flex: 1;
   flex: 1;
 }
 
 /* Metadata */
 
 #meta {
+  display: -webkit-flex;
   display: flex;
 }
 
@@ -74,6 +76,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 #default {
+  -webkit-flex: 1;
   flex: 1;
   text-align: right;
 }

--- a/iron-doc-viewer.css
+++ b/iron-doc-viewer.css
@@ -14,10 +14,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   padding: 16px;
 }
 :host(.loaded) {
+  display: -webkit-flex;
   display: flex;
 }
 #content {
   @apply(--paper-font-body1);
+  -webkit-flex-basis: 100%;
   flex-basis: 100%;
   width: 48em;
   max-width: 48em;


### PR DESCRIPTION
Everyone knows Safari is the best browser. C'mon now.

On a serious note, fix entails adding `-webkit-` vendor prefixes that Safari requires for flex support. Otherwise there were numerous issues on Safari such as the element not rendering at all because `:host(.loaded) { display: flex; }` had no effect (needed to add `display: -webkit-flex;`).
