### PR TITLE
fix #43, FF cant open behaviors

### DIFF
--- a/iron-doc-viewer.html
+++ b/iron-doc-viewer.html
@@ -229,7 +229,7 @@ property.
     },
 
     _broadcastBehavior: function(ev) {
-      this.fire('iron-doc-viewer-component-selected', ev.srcElement._templateInstance.item);
+      this.fire('iron-doc-viewer-component-selected', ev.target._templateInstance.item);
     }
   });
 


### PR DESCRIPTION
Firefox clicking on behaviors did not work. I used a Chrome-only property.
