### PR TITLE
fix property name wrapping

### DIFF
--- a/iron-doc-property.css
+++ b/iron-doc-property.css
@@ -24,7 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 #transitionMask {
   position: relative;
   overflow: hidden;
-  padding-left: 160px;
 }
 
 [hidden] {
@@ -36,9 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
-  position: absolute;
-  left: 0;
-  top: 0;
+  float: left;
 }
 
 #signature .name {
@@ -47,7 +44,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 :host([function]) #signature {
   position: static;
-  margin-left: -160px;
   width: 100%;
 }
 
@@ -60,6 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 #details {
+  margin-left: 160px;
   flex: 1;
 }
 

--- a/iron-doc-viewer.css
+++ b/iron-doc-viewer.css
@@ -52,6 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   overflow-x: auto;
   padding: 12px 24px;
   font-size: 15px;
+  word-wrap: break-word;
 }
 
 #summary marked-element::shadow #content table {
@@ -148,4 +149,3 @@ iron-doc-property[configuration] {
   padding: 16px 24px;
   cursor: pointer;
 }
-

--- a/test/iron-doc-viewer.html
+++ b/test/iron-doc-viewer.html
@@ -106,12 +106,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         describe('edge cases', function() {
 
-          // TODO(nevir): Cannot enable until https://github.com/Polymer/polymer/issues/1200
-          it.skip('throws when a bound and JSON descriptor are provided', function() {
-            expect(function() {
-              fixture('json-and-bound', {descriptor: ELEMENT});
-            }).to.throw(Error, /descriptor/i);
-          });
+        //   // TODO(nevir): Cannot enable until https://github.com/Polymer/polymer/issues/1200
+        //   it.skip('throws when a bound and JSON descriptor are provided', function() {
+        //     expect(function() {
+        //       fixture('json-and-bound', {descriptor: ELEMENT});
+        //     }).to.throw(Error, /descriptor/i);
+        //   });
 
         });
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-doc-viewer/issues/45 by removing the absolute layout. 

Before:
![screen shot 2015-06-19 at 4 41 29 pm](https://cloud.githubusercontent.com/assets/1369170/8264918/126cada2-16a2-11e5-8415-b48fe54f8f17.png)

After:
![screen shot 2015-06-19 at 4 29 06 pm](https://cloud.githubusercontent.com/assets/1369170/8264887/5db8fa8c-16a1-11e5-95cc-5134fd446ce9.png)

As a bonus, I also added word-wrapping to the `<pre>` code, as otherwise that got cutoff. 

Before:
![screen shot 2015-06-19 at 4 38 23 pm](https://cloud.githubusercontent.com/assets/1369170/8264902/aae95234-16a1-11e5-839a-aaf1cda5ea16.png)

After:
![screen shot 2015-06-19 at 4 31 41 pm](https://cloud.githubusercontent.com/assets/1369170/8264888/6050c194-16a1-11e5-87d1-4fd9cf66bc75.png)

/cc @atotic @frankiefu 
