### PR TITLE
remove references to ::shadow

### DIFF
--- a/iron-doc-property.css
+++ b/iron-doc-property.css
@@ -104,7 +104,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 #params marked-element {
   display: inline-block;
 }
-#params marked-element::shadow #content p {
+#params .markdown-html p {
   margin: 0;
 }
 
@@ -114,15 +114,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   display: block;
 }
 
-#desc::shadow #content > :first-child {
+#desc .markdown-html > :first-child {
   margin-top: 0;
 }
 
-#desc::shadow #content > :last-child {
+#desc .markdown-html > :last-child {
   margin-bottom: 0;
 }
 
-#desc::shadow #content #content code {
+#desc .markdown-html code {
   @apply(--paper-font-code1);
 }
 

--- a/iron-doc-property.html
+++ b/iron-doc-property.html
@@ -38,15 +38,21 @@ Give it a hydrolysis `PropertyDescriptor` (via `descriptor`), and watch it go!
             <li hidden$="{{!item.type}}">
               <span class="name">{{item.name}}</span>
               <span class="type">{{item.type}}</span>
-              <marked-element markdown="{{item.desc}}"></marked-element>
+              <marked-element markdown="{{item.desc}}">
+                <div class="markdown-html"></div>
+              </marked-element>
             </li>
           </template>
           <li class="return" hidden$="{{!descriptor.return}}">Returns
             <span class="type">{{descriptor.return.type}}</span>
-            <marked-element markdown="{{descriptor.return.desc}}"></marked-element>
+            <marked-element markdown="{{descriptor.return.desc}}">
+              <div class="markdown-html"></div>
+            </marked-element>
           </li>
         </ol>
-        <marked-element id="desc" markdown="{{descriptor.desc}}" hidden$="{{!descriptor.desc}}"></marked-element>
+        <marked-element id="desc" markdown="{{descriptor.desc}}" hidden$="{{!descriptor.desc}}">
+          <div class="markdown-html"></div>
+        </marked-element>
       </div>
     </div>
   </template>

--- a/iron-doc-viewer.css
+++ b/iron-doc-viewer.css
@@ -45,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   padding: 4px 0;
 }
 
-#summary marked-element::shadow #content pre {
+#summary .markdown-html pre {
   background-color: var(--paper-grey-50);
   border: solid #e5e5e5;
   border-width: 1px 0;
@@ -55,52 +55,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   word-wrap: break-word;
 }
 
-#summary marked-element::shadow #content table {
+#summary .markdown-html table {
   width: 100%;
   border-collapse: collapse;
   margin: 12px 0;
   border-top: 1px solid #e5e5e5;
 }
 
-#summary marked-element::shadow #content tr {
+#summary .markdown-html tr {
   border-bottom: 1px solid #e5e5e5;
   padding: 0 18px;
 }
 
-#summary marked-element::shadow #content td,
-#summary marked-element::shadow #content th {
+#summary .markdown-html td,
+#summary .markdown-html th {
   padding: 6px 12px;
 }
 
-#summary marked-element::shadow #content td:first-child,
-#summary marked-element::shadow #content th:first-child {
+#summary .markdown-html td:first-child,
+#summary .markdown-html th:first-child {
   padding-left: 24px;
 }
 
-#summary marked-element::shadow #content td:last-child,
-#summary marked-element::shadow #content th:last-child {
+#summary .markdown-html td:last-child,
+#summary .markdown-html th:last-child {
   padding-right: 24px;
 }
 
-#summary marked-element::shadow #content code {
+#summary .markdown-html code {
   @apply(--paper-font-code1);
 }
 
-#summary marked-element::shadow #content p {
+#summary .markdown-html p {
   padding: 0 24px;
 }
 
-#summary marked-element::shadow #content a {
+#summary .markdown-html a {
   color: var(--paper-indigo-a200);
   font-weight: 500;
   text-decoration: none;
 }
 
-#summary marked-element::shadow #content h1,
-#summary marked-element::shadow #content h2,
-#summary marked-element::shadow #content h3,
-#summary marked-element::shadow #content h4,
-#summary marked-element::shadow #content h5 {
+#summary .markdown-html h1,
+#summary .markdown-html h2,
+#summary .markdown-html h3,
+#summary .markdown-html h4,
+#summary .markdown-html h5 {
   padding: 0 18px;
 }
 

--- a/iron-doc-viewer.html
+++ b/iron-doc-viewer.html
@@ -8,7 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../marked-element/marked-element.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../paper-styles/shadow.html">
+<link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-button/paper-button.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../prism-element/prism-highlighter.html">
@@ -52,7 +54,9 @@ property.
 
     <section id="summary" class="card" hidden$="[[!descriptor.desc]]">
       <header>Documentation</header>
-      <marked-element markdown="{{descriptor.desc}}"></marked-element>
+      <marked-element markdown="{{descriptor.desc}}">
+        <div class="markdown-html"></div>
+      </marked-element>
     </section>
 
     <nav id="api">


### PR DESCRIPTION
`marked-element` can now render to a light DOM child, so that we can style the output without having to use `::shadow`, which is woefully deprecated.

There should be no visible change as a result of this PR. Sorta proof:

<img width="699" alt="screen shot 2015-09-09 at 11 27 47 am" src="https://cloud.githubusercontent.com/assets/1369170/9770609/dfe436d2-56e5-11e5-8f72-d40062abe329.png">
<img width="708" alt="screen shot 2015-09-09 at 11 27 54 am" src="https://cloud.githubusercontent.com/assets/1369170/9770611/e16f74bc-56e5-11e5-9fec-1fe8c371cb3c.png">

/cc @garlicnation @atotic 
