### PR TITLE
give the styles a wash and dry

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       body {
         margin: 16px;
       }
-      
+
       iron-doc-viewer {
         margin: 0 auto;
         max-width: 48em;
@@ -117,7 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         ],
         "is": "doc-demo",
-        "desc": "This is an example of how `iron-doc-viewer` will render various types of\ninformation. You can use it as a style guide to see how various data will be\nrepresented. Markdown is used to format descriptive text throughout.\n\n# Level 1 Heading\n\nThis is a level one heading. **Bold text** and *italic text* are represented\nappropriately. [Links](#) have black underlines.\n\n## Level 2 Heading\n\nThis is a level two heading. `inline code` can be represented.\n\n    <html>\n      <p>This is a code block. Its syntax is highlighted automatically.</p>\n    </html>\n\n### Level 3 Heading\n\nLists can also be used as you'd expect:\n\n* Unordered Lists\n  * With Nesting\n* Or without nesting\n\nYou can also use ordered lists:\n\n1. First item\n2. Second item\n\n#### Level 4 Heading\n\nHeadings can be used all the way down to level 5.\n\n##### Level 5 Heading\n\nThis concludes our quick rundown of the various styles that you can commonly use."
+        "desc": "This is an example of how `iron-doc-viewer` will render various types of\ninformation. You can use it as a style guide to see how various data will be\nrepresented. Markdown is used to format descriptive text throughout.\n\n# Level 1 Heading\n\nThis is a level one heading. **Bold text** and *italic text* are represented\nappropriately. [Links](#) are blue.\n\n## Level 2 Heading\n\nThis is a level two heading. `inline code` can be represented.\n\n    <html>\n      <p>This is a code block. Its syntax is highlighted automatically.</p>\n    </html>\n\n### Level 3 Heading\n\nLists can also be used as you'd expect:\n\n* Unordered Lists\n  * With Nesting\n* Or without nesting\n\nYou can also use ordered lists:\n\n1. First item\n2. Second item\n\n#### Level 4 Heading\n\nHeadings can be used all the way down to level 5.\n\n##### Level 5 Heading\n\nThis concludes our quick rundown of the various styles that you can commonly use."
       }
 
       document.querySelector('iron-doc-viewer').descriptor = descriptor;

--- a/iron-doc-property-styles.html
+++ b/iron-doc-property-styles.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .deeplink:hover {
-        color: #666;
+        color: var(--paper-pink-500);
       }
 
       #signature {
@@ -46,6 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overflow: hidden;
         text-overflow: ellipsis;
         width: 260px;
+        color: black;
       }
 
       #signature .name {
@@ -159,6 +160,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       #meta {
         transition: opacity ease-in-out 150ms;
+        color: var(--paper-blue-500);
       }
       #desc {
         transition: transform ease-in-out 150ms, opacity  ease-in-out 150ms;

--- a/iron-doc-viewer-styles.html
+++ b/iron-doc-viewer-styles.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .deeplink:hover {
-        color: #555;
+        color: var(--paper-pink-500);
       }
 
       #api {
@@ -45,16 +45,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #api header {
-        @apply(--paper-font-subhead);
+        @apply(--paper-font-title);
 
         flex: 1;
-        padding-left: 16px;
       }
 
       #api a {
         @apply(--paper-font-button);
 
-        color: var(--paper-grey-800);
+        color: var(--var(--paper-grey-200)-800);
         cursor: pointer;
         display: block;
         padding: 4px 16px;
@@ -67,9 +66,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #summary .markdown-html pre {
-        background-color: var(--paper-grey-50);
-        border: solid #e5e5e5;
-        border-width: 1px 0;
+        background-color: var(--paper-grey-200);
+        border-radius: 3px;
         font-size: 15px;
         overflow-x: auto;
         padding: 12px 24px;
@@ -77,14 +75,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #summary .markdown-html table {
+        background-color: var(--paper-grey-200);
         border-collapse: collapse;
-        border-top: 1px solid #e5e5e5;
         margin: 12px 0;
         width: 100%;
       }
 
       #summary .markdown-html tr {
-        border-bottom: 1px solid #e5e5e5;
         padding: 0 18px;
       }
 
@@ -103,12 +100,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         padding-right: 24px;
       }
 
+      #summary .markdown-html td:first-child > code {
+        color: black;
+        font-weight: bold;
+      }
+
       #summary .markdown-html code {
         @apply(--paper-font-code1);
+        background: var(--paper-grey-200);
+        padding: 3px;
+        border-radius: 3px;
       }
 
       #summary .markdown-html p {
-        padding: 0 24px;
+        padding: 0;
       }
 
       #summary .markdown-html a {
@@ -117,39 +122,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         text-decoration: none;
       }
 
-      #summary .markdown-html h1,
-      #summary .markdown-html h2,
-      #summary .markdown-html h3,
-      #summary .markdown-html h4,
-      #summary .markdown-html h5 {
-        padding: 0 18px;
+      #summary .markdown-html h1 {
+        @apply(--paper-font-display1);
+      }
+
+      #summary .markdown-html h2 {
+        @apply(--paper-font-headline);
+      }
+
+      #summary .markdown-html h3 {
+        @apply(--paper-font-title);
+      }
+
+      #summary .markdown-html h4 {
+        @apply(--paper-font-subhead);
       }
 
       /* Property Sections */
 
       .card {
-        background: white;
-        border-radius: 2px;
-        border: 1px solid #e5e5e5;
         margin-bottom: 20px;
       }
 
       .card > header {
-        border-bottom: 1px solid #e5e5e5;
         font-size: 20px;
         font-weight: 400;
         line-height: 28px;
-        padding: 14px 24px;
+        padding: 14px 0;
 
         @apply(--iron-doc-viewer-header);
       }
 
+      nav {
+        border-bottom: 1px solid var(--paper-grey-200);
+      }
+
       iron-doc-property {
-        border-bottom: 1px solid #e5e5e5;
+        background: var(--paper-grey-200);
+      }
+
+      iron-doc-property:first-of-type {
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
       }
 
       iron-doc-property:last-of-type {
-        border-bottom-width: 0;
+        border-bottom-left-radius: 3px;
+        border-bottom-right-radius: 3px;
       }
 
       /* Private Properties */
@@ -160,6 +179,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       :host(.show-private) iron-doc-property[private] {
         display: block;
+        background: var(--paper-grey-300);
       }
 
       iron-doc-property[configuration] {
@@ -167,7 +187,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #behaviors > p {
-        border-bottom: 1px solid #e5e5e5;
         box-sizing: border-box;
         cursor: pointer;
         display: block;
@@ -176,6 +195,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       #behaviors > p:last-of-type {
         border-bottom: none;
+      }
+
+      paper-button:hover {
+        color: var(--paper-pink-500);
       }
     </style>
   </template>


### PR DESCRIPTION
The before: https://polygit2.appspot.com/components/iron-doc-viewer/demo/index.html
The after: https://polygit2.appspot.com/iron-doc-viewer+:always-be-colouring/components/iron-doc-viewer/demo/index.html

I've updated all the header styles:
<img width="1345" alt="screen shot 2016-03-10 at 6 15 05 pm" src="https://cloud.githubusercontent.com/assets/1369170/13691250/33291628-e6ec-11e5-8374-0e37d44ff4ea.png">

And the property styles. The private properties are darker (I am welcome to other suggestions here):
<img width="1338" alt="screen shot 2016-03-10 at 6 15 25 pm" src="https://cloud.githubusercontent.com/assets/1369170/13691257/3c17d472-e6ec-11e5-94b7-27bf27b2e417.png">

All the hover links are pink:
<img width="693" alt="screen shot 2016-03-10 at 6 17 02 pm" src="https://cloud.githubusercontent.com/assets/1369170/13691266/4e7f2336-e6ec-11e5-95cb-6164a06b864f.png">

👉 @frankiefu @blasten 
