### PR TITLE
Fixes #88: Fix styles under shadow DOM.

### DIFF
--- a/iron-doc-property-styles.html
+++ b/iron-doc-property-styles.html
@@ -58,7 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         width: 100%;
       }
 
-      :host:not([function]) #signature .params {
+      :host(:not([function])) #signature .params {
         display: none;
       }
 


### PR DESCRIPTION
Removes those pesky parens that show up when you use native shadow DOM.

Does not fix syntax highlighting, which is also broken under shadow DOM, because squeezing the prism.js styles into iron-doc-viewer's shadow DOM is a bigger challenge.
