### PR TITLE
Fix syntax highlighting in shadow DOM.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,7 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {
             "name": "marshal",
             "type": "Function",
-            "desc": "Renders this element into static HTML for offline use.\n\nThis is mostly useful for debugging and one-off documentation generation.\nIf you want to integrate doc generation into your build process, you\nprobably want to be calling `hydrolysis.Analyzer.analyze()` directly.\n",
+            "desc": "Renders this element into static HTML for offline use.\n\nThis is mostly useful for debugging and one-off documentation generation.\nIf you want to integrate doc generation into your build process, you\nprobably want to be calling `hydrolysis.Analyzer.analyze()` directly.\n\n    //This is a code sample in a method description.\n    // It should be highlighted.\n    var amIHighlighted = getSomeCode(iGuess);\n",
             "params": [],
             "function": true,
             "return": {
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {
             "name": "src",
             "type": "string",
-            "desc": "The URL to an import that declares (or transitively imports) the\nelements that you wish to see documented.\n\nIf the URL is relative, it will be resolved relative to the master\ndocument.\n\nIf you change this value after the `&lt;iron-doc-viewer&gt;` has been\ninstantiated, you must call `load()`.\n      ",
+            "desc": "The URL to an import that declares (or transitively imports) the\nelements that you wish to see documented.\n\nIf the URL is relative, it will be resolved relative to the master\ndocument.\n\nIf you change this value after the `<iron-doc-viewer>` has been\ninstantiated, you must call `load()`.\n      ",
             "published": true
           },
           {
@@ -108,12 +108,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ],
             "private": true,
             "function": true
-          },
-          {
-            "name": "enableCustomStyleProperties",
-            "type": "boolean",
-            "private": true,
-            "configuration": true
           }
         ],
         "is": "doc-demo",

--- a/iron-doc-property.html
+++ b/iron-doc-property.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../marked-element/marked-element.html">
+<link rel="import" href="../prism-element/prism-style-import.html">
 <link rel="import" href="iron-doc-property-styles.html">
 
 <!--
@@ -21,6 +22,7 @@ Give it a hydrolysis `PropertyDescriptor` (via `descriptor`), and watch it go!
 <dom-module id="iron-doc-property">
   <template>
     <style include="iron-doc-property-styles"></style>
+    <style include="prism-styles"></style>
 
     <div id="transitionMask">
       <div id="signature">

--- a/iron-doc-viewer.html
+++ b/iron-doc-viewer.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-styles/shadow.html">
 <link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../prism-element/prism-highlighter.html">
+<link rel="import" href="../prism-element/prism-style-import.html">
 <link rel="import" href="iron-doc-property.html">
 <link rel="import" href="iron-doc-viewer-styles.html">
 
@@ -50,6 +51,7 @@ property.
 <dom-module id="iron-doc-viewer">
   <template>
     <style include="iron-doc-viewer-styles"></style>
+    <style include="prism-styles"></style>
 
     <prism-highlighter></prism-highlighter>
 


### PR DESCRIPTION


Also: updated demo to include a code block inside a member description, to make sure that was highlighted correctly, too. 

/cc: @notwaldorf @FredKSchott 
