### PR TITLE
replaced hard coded colors with css variables

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,10 +26,10 @@
     "paper-button": "PolymerElements/paper-button#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.5.0",
-    "prism-element": "PolymerElements/prism-element#^1.0.2",
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
+    "prism-element": "PolymerElements/prism-element#^1.0.2"
   },
   "devDependencies": {
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/bower.json
+++ b/bower.json
@@ -26,10 +26,10 @@
     "paper-button": "PolymerElements/paper-button#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.5.0",
-    "prism-element": "PolymerElements/prism-element#^1.0.2"
+    "prism-element": "PolymerElements/prism-element#^1.0.2",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/iron-doc-property-styles.html
+++ b/iron-doc-property-styles.html
@@ -9,6 +9,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../paper-styles/color.html">
+
+<!--
+### Styling
+
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--iron-doc-viewer-deeplink-color` | Text color of clickable properties and events names | `currentcolor`
+`--iron-doc-viewer-deeplink-color--hover` | Text hover color of properties and events names | `--paper-pink-500`
+`--iron-doc-viewer-signature-color` | Text color of properties and events names | `black`
+`--iron-doc-viewer-annotation-color` | Text color of annotations | `--paper-grey-700`
+`--iron-doc-viewer-default-value-color` | Text color of default value | `--paper-grey-500`
+`--iron-doc-viewer-markdown-link-color` | Text color of markdown links in desc | `--paper-indigo-a200`
+`--iron-doc-viewer-meta-color` | Text color of meta types | `--paper-blue-500`
+
+-->
+
 
 <dom-module id="iron-doc-property-styles">
   <template>
@@ -31,12 +50,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .deeplink {
-        color: currentcolor;
+        color: var(--iron-doc-viewer-deeplink-color, currentcolor);
         text-decoration: none;
       }
 
       .deeplink:hover {
-        color: var(--paper-pink-500);
+        color: var(--iron-doc-viewer-deeplink-color--hover, --paper-pink-500);
       }
 
       #signature {
@@ -46,7 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overflow: hidden;
         text-overflow: ellipsis;
         width: 260px;
-        color: var(--iron-doc-black, black);
+        color: var(--iron-doc-viewer-signature-color, black);
       }
 
       #signature .name {
@@ -81,7 +100,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .annotation {
-        color: var(--paper-grey-700);
+        color: var(--iron-doc-viewer-annotation-color, --paper-grey-700);
         float: right;
       }
 
@@ -94,7 +113,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #default .value {
-        color: var(--paper-grey-500);
+        color: var(--iron-doc-viewer-default-value-color, --paper-grey-500);
         font-size: 12px;
       }
 
@@ -150,7 +169,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #desc .markdown-html a {
-        color: var(--paper-indigo-a200);
+        color: var(--iron-doc-viewer-markdown-link-color, --paper-indigo-a200);
         text-decoration: none;
       }
 
@@ -165,7 +184,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       #meta {
         transition: opacity ease-in-out 150ms;
-        color: var(--paper-blue-500);
+        color: var(--iron-doc-viewer-meta-color, --paper-blue-500);
       }
       #desc {
         transition: transform ease-in-out 150ms, opacity  ease-in-out 150ms;

--- a/iron-doc-property-styles.html
+++ b/iron-doc-property-styles.html
@@ -18,13 +18,13 @@ The following custom properties and mixins are available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--iron-doc-viewer-deeplink-color` | Text color of clickable properties and events names | `currentcolor`
-`--iron-doc-viewer-deeplink-color--hover` | Text hover color of properties and events names | `--paper-pink-500`
-`--iron-doc-viewer-signature-color` | Text color of properties and events names | `black`
-`--iron-doc-viewer-annotation-color` | Text color of annotations | `--paper-grey-700`
-`--iron-doc-viewer-default-value-color` | Text color of default value | `--paper-grey-500`
-`--iron-doc-viewer-markdown-link-color` | Text color of markdown links in desc | `--paper-indigo-a200`
-`--iron-doc-viewer-meta-color` | Text color of meta types | `--paper-blue-500`
+`--iron-doc-viewer-property-deeplink-color` | Text color of clickable properties and events names | `currentcolor`
+`--iron-doc-viewer-property-deeplink-color--hover` | Text hover color of properties and events names | `--paper-pink-500`
+`--iron-doc-viewer-property-signature-color` | Text color of properties and events names | `black`
+`--iron-doc-viewer-property-annotation-color` | Text color of annotations | `--paper-grey-700`
+`--iron-doc-viewer-property-default-value-color` | Text color of default value | `--paper-grey-500`
+`--iron-doc-viewer-property-markdown-link-color` | Text color of markdown links in desc | `--paper-indigo-a200`
+`--iron-doc-viewer-property-meta-color` | Text color of meta types | `--paper-blue-500`
 
 -->
 
@@ -50,12 +50,12 @@ Custom property | Description | Default
       }
 
       .deeplink {
-        color: var(--iron-doc-viewer-deeplink-color, currentcolor);
+        color: var(--iron-doc-viewer-property-deeplink-color, currentcolor);
         text-decoration: none;
       }
 
       .deeplink:hover {
-        color: var(--iron-doc-viewer-deeplink-color--hover, --paper-pink-500);
+        color: var(--iron-doc-viewer-property-deeplink-color--hover, --paper-pink-500);
       }
 
       #signature {
@@ -65,7 +65,7 @@ Custom property | Description | Default
         overflow: hidden;
         text-overflow: ellipsis;
         width: 260px;
-        color: var(--iron-doc-viewer-signature-color, black);
+        color: var(--iron-doc-viewer-property-signature-color, black);
       }
 
       #signature .name {
@@ -100,7 +100,7 @@ Custom property | Description | Default
       }
 
       .annotation {
-        color: var(--iron-doc-viewer-annotation-color, --paper-grey-700);
+        color: var(--iron-doc-viewer-property-annotation-color, --paper-grey-700);
         float: right;
       }
 
@@ -113,7 +113,7 @@ Custom property | Description | Default
       }
 
       #default .value {
-        color: var(--iron-doc-viewer-default-value-color, --paper-grey-500);
+        color: var(--iron-doc-viewer-property-default-value-color, --paper-grey-500);
         font-size: 12px;
       }
 
@@ -169,7 +169,7 @@ Custom property | Description | Default
       }
 
       #desc .markdown-html a {
-        color: var(--iron-doc-viewer-markdown-link-color, --paper-indigo-a200);
+        color: var(--iron-doc-viewer-property-markdown-link-color, --paper-indigo-a200);
         text-decoration: none;
       }
 
@@ -184,7 +184,7 @@ Custom property | Description | Default
       }
       #meta {
         transition: opacity ease-in-out 150ms;
-        color: var(--iron-doc-viewer-meta-color, --paper-blue-500);
+        color: var(--iron-doc-viewer-property-meta-color, --paper-blue-500);
       }
       #desc {
         transition: transform ease-in-out 150ms, opacity  ease-in-out 150ms;

--- a/iron-doc-property-styles.html
+++ b/iron-doc-property-styles.html
@@ -19,7 +19,7 @@ The following custom properties and mixins are available for styling:
 Custom property | Description | Default
 ----------------|-------------|----------
 `--iron-doc-viewer-property-deeplink-color` | Text color of clickable properties and events names | `currentcolor`
-`--iron-doc-viewer-property-deeplink-color--hover` | Text hover color of properties and events names | `--paper-pink-500`
+`--iron-doc-viewer-property-deeplink-color-hover` | Text hover color of properties and events names | `--paper-pink-500`
 `--iron-doc-viewer-property-signature-color` | Text color of properties and events names | `black`
 `--iron-doc-viewer-property-annotation-color` | Text color of annotations | `--paper-grey-700`
 `--iron-doc-viewer-property-default-value-color` | Text color of default value | `--paper-grey-500`
@@ -55,7 +55,7 @@ Custom property | Description | Default
       }
 
       .deeplink:hover {
-        color: var(--iron-doc-viewer-property-deeplink-color--hover, --paper-pink-500);
+        color: var(--iron-doc-viewer-property-deeplink-color-hover, --paper-pink-500);
       }
 
       #signature {

--- a/iron-doc-property-styles.html
+++ b/iron-doc-property-styles.html
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overflow: hidden;
         text-overflow: ellipsis;
         width: 260px;
-        color: black;
+        color: var(--iron-doc-black, black);
       }
 
       #signature .name {
@@ -81,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .annotation {
-        color: #666;
+        color: var(--paper-grey-700);
         float: right;
       }
 
@@ -94,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #default .value {
-        color: #999;
+        color: var(--paper-grey-500);
         font-size: 12px;
       }
 
@@ -147,6 +147,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       #desc .markdown-html code {
         @apply(--paper-font-code1);
+      }
+
+      #desc .markdown-html a {
+        color: var(--paper-indigo-a200);
+        text-decoration: none;
       }
 
       .return {

--- a/iron-doc-viewer-styles.html
+++ b/iron-doc-viewer-styles.html
@@ -20,7 +20,7 @@ Custom property | Description | Default
 ----------------|-------------|----------
 `--iron-doc-viewer-text-color` | Default Text color | `--paper-grey-900`
 `--iron-doc-viewer-title-link` | Text color of title links | `currentcolor`
-`--iron-doc-viewer-title-link--hover` | Text hover color of title links | `--paper-pink-500`
+`--iron-doc-viewer-title-link-hover` | Text hover color of title links | `--paper-pink-500`
 `--iron-doc-viewer-markdown-background` | Background color of the summary markdown | `--paper-grey-200`
 `--iron-doc-viewer-api-link-color` | Text color of links in api | `--paper-grey-800`
 `--iron-doc-viewer-code-color` | Text color of td in summary | `black`
@@ -28,7 +28,7 @@ Custom property | Description | Default
 `--iron-doc-viewer-nav-border` | Border color of nav hr | `--paper-grey-200`
 `--iron-doc-viewer-property-background` | Background color of properties and methods | `--paper-grey-200`
 `--iron-doc-viewer-private-property-background` | Background color of private properties and methods | `--paper-grey-300`
-`--iron-doc-viewer-button--hover` | Button text hover color | `--paper-pink-500`
+`--iron-doc-viewer-button-hover` | Button text hover color | `--paper-pink-500`
 
 -->
 
@@ -58,7 +58,7 @@ Custom property | Description | Default
       }
 
       .deeplink:hover {
-        color: var(--iron-doc-viewer-title-link--hover, --paper-pink-500);
+        color: var(--iron-doc-viewer-title-link-hover, --paper-pink-500);
       }
 
       #api {
@@ -224,7 +224,7 @@ Custom property | Description | Default
       }
 
       paper-button:hover {
-        color: var(--iron-doc-viewer-button--hover, --paper-pink-500);
+        color: var(--iron-doc-viewer-button-hover, --paper-pink-500);
       }
     </style>
   </template>

--- a/iron-doc-viewer-styles.html
+++ b/iron-doc-viewer-styles.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       :host {
         @apply(--paper-font-body1);
 
-        color: #212121;
+        color: var(--paper-grey-900);
         display: block;
       }
 
@@ -101,7 +101,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #summary .markdown-html td:first-child > code {
-        color: black;
+        color: var(--iron-doc-black, black);
         font-weight: bold;
       }
 

--- a/iron-doc-viewer-styles.html
+++ b/iron-doc-viewer-styles.html
@@ -9,6 +9,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../paper-styles/color.html">
+
+<!--
+### Styling
+
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--iron-doc-viewer-text-color` | Default Text color | `--paper-grey-900`
+`--iron-doc-viewer-title-link` | Text color of title links | `currentcolor`
+`--iron-doc-viewer-title-link--hover` | Text hover color of title links | `--paper-pink-500`
+`--iron-doc-viewer-markdown-background` | Background color of the summary markdown | `--paper-grey-200`
+`--iron-doc-viewer-api-link-color` | Text color of links in api | `--paper-grey-800`
+`--iron-doc-viewer-code-color` | Text color of td in summary | `black`
+`--iron-doc-viewer-summary-link-color` | Text color of link in summary markdown | `--paper-indigo-a200`
+`--iron-doc-viewer-nav-border` | Border color of nav hr | `--paper-grey-200`
+`--iron-doc-viewer-property-background` | Background color of properties and methods | `--paper-grey-200`
+`--iron-doc-viewer-private-property-background` | Background color of private properties and methods | `--paper-grey-300`
+`--iron-doc-viewer-button--hover` | Button text hover color | `--paper-pink-500`
+
+-->
 
 <dom-module id="iron-doc-viewer-styles">
   <template>
@@ -16,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       :host {
         @apply(--paper-font-body1);
 
-        color: var(--paper-grey-900);
+        color: var(--iron-doc-viewer-text-color, --paper-grey-900);
         display: block;
       }
 
@@ -31,12 +53,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .deeplink {
-        color: currentcolor;
+        color: var(--iron-doc-viewer-title-link, currentcolor);
         text-decoration: none;
       }
 
       .deeplink:hover {
-        color: var(--paper-pink-500);
+        color: var(--iron-doc-viewer-title-link--hover, --paper-pink-500);
       }
 
       #api {
@@ -53,7 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       #api a {
         @apply(--paper-font-button);
 
-        color: var(--paper-grey-800);
+        color: var(--iron-doc-viewer-api-link-color, --paper-grey-800);
         cursor: pointer;
         display: block;
         padding: 4px 16px;
@@ -66,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #summary .markdown-html pre {
-        background-color: var(--paper-grey-200);
+        background-color: var(--iron-doc-viewer-markdown-background, --paper-grey-200);
         border-radius: 3px;
         font-size: 15px;
         overflow-x: auto;
@@ -75,7 +97,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #summary .markdown-html table {
-        background-color: var(--paper-grey-200);
+        background-color: var(--iron-doc-viewer-markdown-background, --paper-grey-200);
         border-collapse: collapse;
         margin: 12px 0;
         width: 100%;
@@ -101,13 +123,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #summary .markdown-html td:first-child > code {
-        color: var(--iron-doc-black, black);
+        color: var(--iron-doc-viewer-td-color, black );
         font-weight: bold;
       }
 
       #summary .markdown-html code {
         @apply(--paper-font-code1);
-        background: var(--paper-grey-200);
+        background: var(--iron-doc-viewer-markdown-background, --paper-grey-200);
         padding: 3px;
         border-radius: 3px;
       }
@@ -119,7 +141,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       #summary .markdown-html a {
         background: none;
         @apply(--paper-font-body1);
-        color: var(--paper-indigo-a200);
+        color: var(--iron-doc-viewer-summary-link-color, --paper-indigo-a200);
         font-weight: 500;
         text-decoration: none;
       }
@@ -158,11 +180,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       nav {
-        border-bottom: 1px solid var(--paper-grey-200);
+        border-bottom: 1px solid var(--iron-doc-viewer-nav-border, --paper-grey-200);
       }
 
       iron-doc-property {
-        background: var(--paper-grey-200);
+        background: var(--iron-doc-viewer-property-background, --paper-grey-200);
       }
 
       iron-doc-property:first-of-type {
@@ -183,7 +205,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       :host(.show-private) iron-doc-property[private] {
         display: block;
-        background: var(--paper-grey-300);
+        background: var(--iron-doc-viewer-private-property-background, --paper-grey-300);
       }
 
       iron-doc-property[configuration] {
@@ -202,7 +224,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       paper-button:hover {
-        color: var(--paper-pink-500);
+        color: var(--iron-doc-viewer-button--hover, --paper-pink-500);
       }
     </style>
   </template>

--- a/iron-doc-viewer-styles.html
+++ b/iron-doc-viewer-styles.html
@@ -123,7 +123,7 @@ Custom property | Description | Default
       }
 
       #summary .markdown-html td:first-child > code {
-        color: var(--iron-doc-viewer-td-color, black );
+        color: var(--iron-doc-viewer-td-color, black);
         font-weight: bold;
       }
 


### PR DESCRIPTION
We are using iron-doc-viewer in our documentation pages. We need to able to theme iron-doc-viewer to match the dark theme of our components so that api documentation isn't blindingly white. 
Most of the styles had css variables, I filled in the rest. Paper-styles/color.html didn't have a black variable; therefore, I created --iron-doc-black. 
Thank you for checking this out and please let me know if I need to make changes. 