### PR TITLE
Fix reference to property

### DIFF
--- a/iron-doc-property.html
+++ b/iron-doc-property.html
@@ -32,7 +32,7 @@ Give it a hydrolysis `PropertyDescriptor` (via `descriptor`), and watch it go!
           <span id="type" class="type">{{descriptor.type}}</span>
           <span class="annotation">[[_getAnnotation(descriptor)]]</span>
         </div>
-        <ol id="params" hidden$="{{_computeHideParams(descriptor,return)}}">
+        <ol id="params" hidden$="{{_computeHideParams(descriptor, descriptor.return)}}">
           <template is="dom-repeat" items="{{descriptor.params}}">
             <li hidden$="{{!item.type}}">
               <span class="name">{{item.name}}</span>


### PR DESCRIPTION
This came up in working on the linter (return is not a valid variable name in javascript, so parsing complained). It looks like this was intended to be written as `descriptor.return` as the second arg, as `return` doesn't seem to be a property on this element.

I haven't tested this change locally, just going through the list of issues that came up with the expression parsing code in the linter.