### PR TITLE
Support scrollToAnchor from iron-doc-(element|mixin|namespace).

### DIFF
--- a/iron-doc-behavior.html
+++ b/iron-doc-behavior.html
@@ -112,17 +112,19 @@
       },
 
       /**
-       * Scrolls to the currently selected anchor, as identified
-       * by the URL hash. Whichever element or script is in charge
-       * of routing should call this method on initial page load and
-       * on hashchange events.
+       * Scroll to the descriptor (element, function, etc.) with an `anchor-id`
+       * matching the given URL hash (including the `#`). If no hash is
+       * specified, uses `window.location.hash`.
+       *
+       * Whichever element or script is in charge of routing should call this
+       * method on initial page load and on `hashchange` events.
        */
       scrollToAnchor: function(hash) {
-        // ToDo: handle linking to private members
-        if (hash && hash.length > 1) {
-          // ensure all dom-repeats have rendered.
+        hash = hash || window.location.hash;
+        if (hash && hash.length > 0) {
+          // Ensure all dom-repeats have rendered.
           Polymer.dom.flush();
-          var anchorId = window.location.hash.slice(1);
+          var anchorId = hash.slice(1);
           var elementToFocus = this.$$('[anchor-id="' + anchorId + '"]');
           if (elementToFocus) {
             elementToFocus.scrollIntoView();
@@ -169,17 +171,16 @@
         return element.classname || element.tagname;
       },
 
-      _compareElements: function(a, b) {
-        if (a.name && b.name && a.name !== b.name) {
-          return a.name.localeCompare(b.name);
-        }
-        if (a.tagname && b.tagname && a.tagname !== b.tagname) {
-          return a.tagname.localeCompare(b.tagname);
-        }
-        if (a.classname && b.classname && a.classname !== b.classname) {
-          return a.classname.localeCompare(b.classname);
-        }
-        return -1;
+      /**
+       * Compare two analysis descriptors (elements, functions, etc.) by
+       * display name.
+       */
+      _compareDescriptors: function(a, b) {
+        // Elements display as "<tagname> (classname)" or "classname", while
+        // everything else displays as "name". Sort according to that format.
+        var aName = (a.name || '') + (a.tagname || '') + (a.classname || '');
+        var bName = (b.name || '') + (b.tagname || '') + (b.classname || '');
+        return aName.localeCompare(bName);
       },
 
     };

--- a/iron-doc-behavior.html
+++ b/iron-doc-behavior.html
@@ -111,6 +111,25 @@
         return prefix + type + suffix;
       },
 
+      /**
+       * Scrolls to the currently selected anchor, as identified
+       * by the URL hash. Whichever element or script is in charge
+       * of routing should call this method on initial page load and
+       * on hashchange events.
+       */
+      scrollToAnchor: function(hash) {
+        // ToDo: handle linking to private members
+        if (hash && hash.length > 1) {
+          // ensure all dom-repeats have rendered.
+          Polymer.dom.flush();
+          var anchorId = window.location.hash.slice(1);
+          var elementToFocus = this.$$('[anchor-id="' + anchorId + '"]');
+          if (elementToFocus) {
+            elementToFocus.scrollIntoView();
+          }
+        }
+      },
+
       _getElementName: function(element) {
         var name = '';
         if (element.tagname) {

--- a/iron-doc-behavior.html
+++ b/iron-doc-behavior.html
@@ -177,10 +177,17 @@
        */
       _compareDescriptors: function(a, b) {
         // Elements display as "<tagname> (classname)" or "classname", while
-        // everything else displays as "name". Sort according to that format.
-        var aName = (a.name || '') + (a.tagname || '') + (a.classname || '');
-        var bName = (b.name || '') + (b.tagname || '') + (b.classname || '');
-        return aName.localeCompare(bName);
+        // everything else displays as "name".
+        if (a.name != b.name) {
+          return (a.name || '').localeCompare(b.name || '');
+        }
+        if (a.tagname != b.tagname) {
+          return (a.tagname || '').localeCompare(b.tagname || '');
+        }
+        if (a.classname != b.classname) {
+          return (a.classname || '').localeCompare(b.classname || '');
+        }
+        return 0;
       },
 
     };

--- a/iron-doc-behavior.html
+++ b/iron-doc-behavior.html
@@ -170,10 +170,16 @@
       },
 
       _compareElements: function(a, b) {
-        if (a.tagname === b.tagname) {
-          return a.classname == null ? -1 : a.classname.localeCompare(b.classname);
+        if (a.name && b.name && a.name !== b.name) {
+          return a.name.localeCompare(b.name);
         }
-        return a.tagname == null ? -1 : b.tagname == null ? 1 : a.tagname.localeCompare(b.tagname);
+        if (a.tagname && b.tagname && a.tagname !== b.tagname) {
+          return a.tagname.localeCompare(b.tagname);
+        }
+        if (a.classname && b.classname && a.classname !== b.classname) {
+          return a.classname.localeCompare(b.classname);
+        }
+        return -1;
       },
 
     };

--- a/iron-doc-element.html
+++ b/iron-doc-element.html
@@ -38,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           target$="[[_superclassTarget(descriptor.superclass)]]"
           href$="[[_superclassUrl(descriptor.superclass)]]">[[descriptor.superclass]]</a>
       <span hidden$="[[!descriptor.mixins]]">
-        with <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareElements">
+        with <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareDescriptors">
           <a class="name deeplink" href$="[[baseHref]]/mixins/[[item]]">[[item]]</a>
         </template>
       </span>
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="metadata">Path: <span class="code">[[descriptor.path]]</span></div>
     <div class="metadata" hidden$="[[!descriptor.behaviors]]">Behaviors:
-      <template is="dom-repeat" items="[[descriptor.behaviors]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[descriptor.behaviors]]" sort="_compareDescriptors">
         <a class="name deeplink" href$="[[baseHref]]/behaviors/[[item]]">[[item]]</a>
       </template>
     </div>
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
       <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
       <div hidden$="[[!descriptor.properties.length]]">
-        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]" sort="_compareElements">
+        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]" sort="_compareDescriptors">
           <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
         </template>
       </div>
@@ -74,14 +74,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
       <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]" sort="_compareDescriptors">
         <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-function>
       </template>
     </section>
 
     <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
       <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]" sort="_compareDescriptors">
         <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>

--- a/iron-doc-element.html
+++ b/iron-doc-element.html
@@ -38,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           target$="[[_superclassTarget(descriptor.superclass)]]"
           href$="[[_superclassUrl(descriptor.superclass)]]">[[descriptor.superclass]]</a>
       <span hidden$="[[!descriptor.mixins]]">
-        with <template is="dom-repeat" items="[[descriptor.mixins]]">
+        with <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareElements">
           <a class="name deeplink" href$="[[baseHref]]/mixins/[[item]]">[[item]]</a>
         </template>
       </span>
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="metadata">Path: <span class="code">[[descriptor.path]]</span></div>
     <div class="metadata" hidden$="[[!descriptor.behaviors]]">Behaviors:
-      <template is="dom-repeat" items="[[descriptor.behaviors]]">
+      <template is="dom-repeat" items="[[descriptor.behaviors]]" sort="_compareElements">
         <a class="name deeplink" href$="[[baseHref]]/behaviors/[[item]]">[[item]]</a>
       </template>
     </div>
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
       <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
       <div hidden$="[[!descriptor.properties.length]]">
-        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]">
+        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]" sort="_compareElements">
           <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
         </template>
       </div>
@@ -74,14 +74,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
       <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]" sort="_compareElements">
         <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-function>
       </template>
     </section>
 
     <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
       <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]" sort="_compareElements">
         <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>

--- a/iron-doc-element.html
+++ b/iron-doc-element.html
@@ -63,26 +63,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-checkbox checked="{{_showPrivate}}">Show Private</paper-checkbox>
     </nav>
 
-    <section id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
       <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
       <div hidden$="[[!descriptor.properties.length]]">
         <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]">
-          <iron-doc-property-2 anchor-id="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+          <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
         </template>
       </div>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
       <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
       <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]">
-        <iron-doc-function anchor-id="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-function>
+        <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-function>
       </template>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
       <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
       <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]">
-        <iron-doc-property-2 anchor-id="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+        <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>
 
@@ -136,42 +136,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
           return '';
         },
-
-        // TODO(justinfagnani): remove or move to IronDocBehavior?
-
-        // /**
-        //  * Scrolls to the currently selected anchor, as identified
-        //  * by the URL hash. Whichever element or script is in charge
-        //  * of routing should call this method on initial page load and
-        //  * on hashchange events.
-        //  */
-        // scrollToAnchor: function(hash) {
-        //   // ToDo: handle linking to private members
-        //   if (hash && hash.length > 1) {
-        //     // ensure all dom-repeats have rendered.
-        //     Polymer.dom.flush();
-        //     var anchorId = window.location.hash.slice(1);
-        //     var elementToFocus = this.$$('[anchor-id="' + anchorId + '"]');
-        //     if (elementToFocus) {
-        //       elementToFocus.scrollIntoView();
-        //     }
-        //   }
-        // },
-
-        // _collapsedChanged: function() {
-        //   this._collapseToggleLabel = this._collapsed ? 'expand' : 'collapse';
-
-        //   // Bound values aren't exposed to dom-repeat's scope.
-        //   var properties = this.querySelectorAll('iron-doc-property-2');
-        //   for (var i = 0, property; property = properties[i]; i++) {
-        //     property.collapsed = this._collapsed;
-        //   }
-        // },
-
-        // _toggleCollapsed: function() {
-        //   this._collapsed = !this._collapsed;
-        // },
-
       });
     })();
   </script>

--- a/iron-doc-function.html
+++ b/iron-doc-function.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div id="transitionMask">
       <div id="signature">
-        <a id$="[[anchorId]]" href$="#[[anchorId]]" class="name deeplink">[[descriptor.name]]</a>(<span class="params code"><span>[[_paramText]]</span></span>)<!--
+        <a href$="#[[anchorId]]" class="name deeplink">[[descriptor.name]]</a>(<span class="params code"><span>[[_paramText]]</span></span>)<!--
         --><span class="return" hidden$="[[!descriptor.return]]">: <span class="type code">[[descriptor.return.type]]</span></span>
       </div>
       <div id="details">
@@ -46,7 +46,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         properties: {
           _paramText: {
             computed: '_computeParamText(descriptor)',
-          }
+          },
+          anchorId: String
         },
 
         _computeParamText: function(descriptor) {

--- a/iron-doc-mixin.html
+++ b/iron-doc-mixin.html
@@ -63,7 +63,7 @@ property.
 
     <!-- TODO(justinfagnani): mixin signature, format more like element -->
     <div class="metadata" hidden$="[[!descriptor.mixins]]">Mixins:
-      <template is="dom-repeat" items="[[descriptor.mixins]]">
+      <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareElements">
         <a class="name deeplink" href$="[[baseHref]]/mixins/[[item]]">[[item]]</a>
       </template>
     </div>
@@ -83,7 +83,7 @@ property.
     <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
       <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
       <div hidden$="[[!descriptor.properties.length]]">
-        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]">
+        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]" sort="_compareElements">
           <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
         </template>
       </div>
@@ -91,14 +91,14 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
       <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]" sort="_compareElements">
         <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>
 
     <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
       <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]" sort="_compareElements">
         <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>

--- a/iron-doc-mixin.html
+++ b/iron-doc-mixin.html
@@ -80,26 +80,26 @@ property.
       <paper-checkbox checked="{{_showPrivate}}">Show Private</paper-checkbox>
     </nav>
 
-    <section id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
       <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
       <div hidden$="[[!descriptor.properties.length]]">
         <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]">
-          <iron-doc-property-2 anchor-id="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+          <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
         </template>
       </div>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
       <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
       <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]">
-        <iron-doc-property-2 anchor-id="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+        <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
       <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
       <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]">
-        <iron-doc-property-2 anchor-id="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+        <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>
 

--- a/iron-doc-mixin.html
+++ b/iron-doc-mixin.html
@@ -63,7 +63,7 @@ property.
 
     <!-- TODO(justinfagnani): mixin signature, format more like element -->
     <div class="metadata" hidden$="[[!descriptor.mixins]]">Mixins:
-      <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareDescriptors">
         <a class="name deeplink" href$="[[baseHref]]/mixins/[[item]]">[[item]]</a>
       </template>
     </div>
@@ -83,7 +83,7 @@ property.
     <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'properties')]]">
       <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
       <div hidden$="[[!descriptor.properties.length]]">
-        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]" sort="_compareElements">
+        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showPrivate,_showInherited)]]" sort="_compareDescriptors">
           <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
         </template>
       </div>
@@ -91,14 +91,14 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'methods')]]">
       <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showPrivate,_showInherited)]]" sort="_compareDescriptors">
         <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>
 
     <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'events')]]">
       <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
-      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showPrivate,_showInherited)]]" sort="_compareDescriptors">
         <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
       </template>
     </section>

--- a/iron-doc-namespace.html
+++ b/iron-doc-namespace.html
@@ -73,7 +73,7 @@ property.
       <header>
         <a href$="#[[_formatAnchor(prefix,'elements')]]" class="deeplink">Elements</a>
       </header>
-      <template is="dom-repeat" items="[[descriptor.elements]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[descriptor.elements]]" sort="_compareDescriptors">
         <iron-doc-summary
           name="[[_getElementName(item)]]"
           description="[[item.summary]]"
@@ -84,7 +84,7 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'mixins')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'mixins')]]">
       <header><a href$="#[[_formatAnchor(prefix,'mixins')]]" class="deeplink">Mixins</a></header>
-      <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareDescriptors">
         <iron-doc-summary
           name="[[item.name]]"
           description="[[item.summary]]"
@@ -95,7 +95,7 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'behaviors')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'behaviors')]]">
       <header><a href$="#[[_formatAnchor(prefix,'behaviors')]]" class="deeplink">Behaviors</a></header>
-      <template is="dom-repeat" items="[[descriptor.behaviors]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[descriptor.behaviors]]" sort="_compareDescriptors">
         <iron-doc-summary
           name="[[item.name]]"
           description="[[item.summary]]"
@@ -106,7 +106,7 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'functions')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'functions')]]">
       <header><a href$="#[[_formatAnchor(prefix,'functions')]]" class="deeplink">Functions</a></header>
-      <template is="dom-repeat" items="[[descriptor.functions]]" sort="_compareElements">
+      <template is="dom-repeat" items="[[descriptor.functions]]" sort="_compareDescriptors">
         <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'function', item.name)]]" descriptor="[[item]]"></iron-doc-function>
       </template>
     </section>
@@ -114,7 +114,7 @@ property.
     <section anchor-id$="[[_formatAnchor(prefix,'namespaces')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'namespaces')]]">
       <header><a href$="#[[_formatAnchor(prefix,'namespaces')]]" class="deeplink">Namespaces</a></header>
       <div hidden$="[[!descriptor.namespaces.length]]">
-        <template is="dom-repeat" items="[[descriptor.namespaces]]" sort="_compareElements">
+        <template is="dom-repeat" items="[[descriptor.namespaces]]" sort="_compareDescriptors">
           <iron-doc-summary
             name="[[item.name]]"
             description="[[item.summary]]"

--- a/iron-doc-namespace.html
+++ b/iron-doc-namespace.html
@@ -84,7 +84,7 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'mixins')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'mixins')]]">
       <header><a href$="#[[_formatAnchor(prefix,'mixins')]]" class="deeplink">Mixins</a></header>
-      <template is="dom-repeat" items="[[descriptor.mixins]]">
+      <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareElements">
         <iron-doc-summary
           name="[[item.name]]"
           description="[[item.summary]]"
@@ -95,7 +95,7 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'behaviors')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'behaviors')]]">
       <header><a href$="#[[_formatAnchor(prefix,'behaviors')]]" class="deeplink">Behaviors</a></header>
-      <template is="dom-repeat" items="[[descriptor.behaviors]]">
+      <template is="dom-repeat" items="[[descriptor.behaviors]]" sort="_compareElements">
         <iron-doc-summary
           name="[[item.name]]"
           description="[[item.summary]]"
@@ -106,7 +106,7 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'functions')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'functions')]]">
       <header><a href$="#[[_formatAnchor(prefix,'functions')]]" class="deeplink">Functions</a></header>
-      <template is="dom-repeat" items="[[descriptor.functions]]">
+      <template is="dom-repeat" items="[[descriptor.functions]]" sort="_compareElements">
         <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'function', item.name)]]" descriptor="[[item]]"></iron-doc-function>
       </template>
     </section>
@@ -114,7 +114,7 @@ property.
     <section anchor-id$="[[_formatAnchor(prefix,'namespaces')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'namespaces')]]">
       <header><a href$="#[[_formatAnchor(prefix,'namespaces')]]" class="deeplink">Namespaces</a></header>
       <div hidden$="[[!descriptor.namespaces.length]]">
-        <template is="dom-repeat" items="[[descriptor.namespaces]]">
+        <template is="dom-repeat" items="[[descriptor.namespaces]]" sort="_compareElements">
           <iron-doc-summary
             name="[[item.name]]"
             description="[[item.summary]]"

--- a/iron-doc-namespace.html
+++ b/iron-doc-namespace.html
@@ -69,7 +69,7 @@ property.
       <header>[[_namespaceName]] API Reference</header>
     </nav>
 
-    <section id$="[[_formatAnchor(prefix,'elements')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'elements')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'elements')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'elements')]]">
       <header>
         <a href$="#[[_formatAnchor(prefix,'elements')]]" class="deeplink">Elements</a>
       </header>
@@ -82,7 +82,7 @@ property.
       </template>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'mixins')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'mixins')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'mixins')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'mixins')]]">
       <header><a href$="#[[_formatAnchor(prefix,'mixins')]]" class="deeplink">Mixins</a></header>
       <template is="dom-repeat" items="[[descriptor.mixins]]">
         <iron-doc-summary
@@ -93,7 +93,7 @@ property.
       </template>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'behaviors')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'behaviors')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'behaviors')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'behaviors')]]">
       <header><a href$="#[[_formatAnchor(prefix,'behaviors')]]" class="deeplink">Behaviors</a></header>
       <template is="dom-repeat" items="[[descriptor.behaviors]]">
         <iron-doc-summary
@@ -104,14 +104,14 @@ property.
       </template>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'functions')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'functions')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'functions')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'functions')]]">
       <header><a href$="#[[_formatAnchor(prefix,'functions')]]" class="deeplink">Functions</a></header>
       <template is="dom-repeat" items="[[descriptor.functions]]">
-        <iron-doc-function descriptor="[[item]]"></iron-doc-function>
+        <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'function', item.name)]]" descriptor="[[item]]"></iron-doc-function>
       </template>
     </section>
 
-    <section id$="[[_formatAnchor(prefix,'namespaces')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'namespaces')]]">
+    <section anchor-id$="[[_formatAnchor(prefix,'namespaces')]]" class="card" hidden$="[[_noneToShow(_showPrivate,_showInherited,descriptor,'namespaces')]]">
       <header><a href$="#[[_formatAnchor(prefix,'namespaces')]]" class="deeplink">Namespaces</a></header>
       <div hidden$="[[!descriptor.namespaces.length]]">
         <template is="dom-repeat" items="[[descriptor.namespaces]]">


### PR DESCRIPTION
- Support scrollToAnchor from iron-doc-(element|mixin|namespace). Depends on https://github.com/Polymer/docs/pull/2045. Fixes https://github.com/Polymer/docs/issues/2024.
- Link static functions. Fixes #113.
- Sort all the analysis items. Fixes #107.

cc @arthurevans 