### PR TITLE
Property defaults, Polymer metadata, and styling.

### DIFF
--- a/iron-doc-property-2.html
+++ b/iron-doc-property-2.html
@@ -21,12 +21,33 @@ Give it a hydrolysis `PropertyDescriptor` (via `descriptor`), and watch it go!
 <dom-module id="iron-doc-property-2">
   <template>
     <style include="iron-doc-viewer-2-styles"></style>
+    <style>
+      #polymer {
+        margin-left: 12px;
+      }
+
+      #polymer > * {
+        background-color: #efefef;
+        color: #e91e63;
+        padding: 1px 6px;
+        margin-left: 8px;
+        border-radius: 8px;
+      }
+    </style>
 
     <div id="transitionMask">
       <div id="signature">
         <a id$="[[anchorId]]" href$="#[[anchorId]]" class="name deeplink">[[descriptor.name]]</a>
-        <span id="type" class="type" hidden$="[[!descriptor.type]]">: [[descriptor.type]]</span>
+        <code id="type" hidden$="[[!descriptor.type]]">: [[descriptor.type]]</code>
+        <code id="default" hidden$="[[!descriptor.defaultValue]]">= [[descriptor.defaultValue]]</code>
+
+        <span id="polymer">
+          <code hidden$="[[!descriptor.metadata.polymer.notify]]">notifies</code>
+          <code hidden$="[[!descriptor.metadata.polymer.readOnly]]">readOnly</code>
+          <code hidden$="[[!descriptor.metadata.polymer.reflectToAttribute]]">reflectToAttribute</code>
+        </span>
       </div>
+
       <div id="details">
         <div id="meta" hidden$="[[_computeHideMeta(descriptor)]]">
 

--- a/iron-doc-viewer-2-styles.html
+++ b/iron-doc-viewer-2-styles.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: none !important;
       }
 
-      .member, iron-doc-summary, iron-doc-function {
+      .member, iron-doc-summary, iron-doc-function, iron-doc-property-2 {
         @apply --paper-font-body1;
 
         box-sizing: border-box;
@@ -52,11 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         @apply --paper-font-code2;
       }
 
-      code {
-        color: #0d47a1;
-      }
-
-      .code {
+      code, .code {
         @apply --paper-font-code1;
         color: #0d47a1;
       }


### PR DESCRIPTION
- Property default values are now shown as ` = default`.
- Polymer property metadata (`notifies`, `readOnly`, `reflectToAttribute`) are now shown as pills.
- Property sections now have padding and line breaks, same as methods.
- Fixes #126.

![screen shot 2017-05-30 at 10 32 35 pm](https://cloud.githubusercontent.com/assets/48894/26617424/fcce4032-4589-11e7-8a5d-536b05ffe638.png)
