### PR TITLE
Add <iron-doc-class>.

### DIFF
--- a/iron-doc-class.html
+++ b/iron-doc-class.html
@@ -1,0 +1,87 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../marked-element/marked-element.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/shadow.html">
+<link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../prism-element/prism-highlighter.html">
+<link rel="import" href="../prism-element/prism-theme-default.html">
+
+<link rel="import" href="iron-doc-behavior.html">
+<link rel="import" href="iron-doc-function.html">
+<link rel="import" href="iron-doc-property-2.html">
+<link rel="import" href="iron-doc-viewer-2-styles.html">
+
+<dom-module id="iron-doc-class">
+  <template>
+    <style include="iron-doc-viewer-2-styles prism-theme-default"></style>
+
+    <prism-highlighter></prism-highlighter>
+
+    <h1>Class [[descriptor.name]]</h1>
+    <p hidden$="[[!descriptor.summary]]">[[descriptor.summary]]</p>
+
+    <div class="metadata">Path: <span class="code">[[descriptor.path]]</span></div>
+
+    <div class="metadata" hidden$="[[!descriptor.mixins]]">Mixins:
+      <template is="dom-repeat" items="[[descriptor.mixins]]">[[item]]</template>
+    </div>
+
+    <section id="description" class="card" hidden$="[[!descriptor.description]]">
+      <marked-element sanitize markdown="[[descriptor.description]]">
+        <div slot="markdown-html" class="markdown-html"></div>
+      </marked-element>
+    </section>
+
+    <nav id="api">
+      <header>API Reference</header>
+      <label class="checkbox"><input type="checkbox" checked="{{_showInherited::change}}">Show Inherited</label>
+      <label class="checkbox"><input type="checkbox" checked="{{_showProtected::change}}">Show Protected</label>
+    </nav>
+
+    <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'properties')]]">
+      <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
+      <div hidden$="[[!descriptor.properties.length]]">
+        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showProtected,_showInherited)]]" sort="_compareDescriptors">
+          <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+        </template>
+      </div>
+    </section>
+
+    <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'methods')]]">
+      <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showProtected,_showInherited)]]" sort="_compareDescriptors">
+        <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-function>
+      </template>
+    </section>
+
+    <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'events')]]">
+      <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showProtected,_showInherited)]]" sort="_compareDescriptors">
+        <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+      </template>
+    </section>
+
+  </template>
+
+  <script>
+    (function() {
+      /**
+       * Renders documentation describing a JavaScript class.
+      */
+      Polymer({
+        is: 'iron-doc-class',
+        behaviors: [Polymer.IronDocBehavior],
+      });
+    })();
+  </script>
+</dom-module>

--- a/iron-doc-namespace.html
+++ b/iron-doc-namespace.html
@@ -81,6 +81,19 @@ property.
       </template>
     </section>
 
+    <section anchor-id$="[[_formatAnchor(prefix,'classes')]]" class="card" hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'classes')]]">
+      <header>
+        <a href$="#[[_formatAnchor(prefix,'classes')]]" class="deeplink">Classes</a>
+
+      <template is="dom-repeat" items="[[descriptor.classes]]" sort="_compareDescriptors">
+        <iron-doc-summary
+          name="[[item.name]]"
+          description="[[item.summary]]"
+          href="[[baseHref]]/classes/[[_getElementId(item)]]">
+        </iron-doc-summary>
+      </template>
+    </section>
+
     <section anchor-id$="[[_formatAnchor(prefix,'mixins')]]" class="card" hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'mixins')]]">
       <header><a href$="#[[_formatAnchor(prefix,'mixins')]]" class="deeplink">Mixins</a></header>
       <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareDescriptors">

--- a/iron-doc-viewer-2.html
+++ b/iron-doc-viewer-2.html
@@ -20,6 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="iron-doc-namespace.html">
 <link rel="import" href="iron-doc-element.html">
+<link rel="import" href="iron-doc-class.html">
 <link rel="import" href="iron-doc-mixin.html">
 
 <!--
@@ -68,6 +69,9 @@ property.
     </template>
     <template is="dom-if" if="[[_equal(_descriptorType,'mixins')]]" restamp="true">
       <iron-doc-mixin descriptor="[[_currentDescriptor]]"></iron-doc-mixin>
+    </template>
+    <template is="dom-if" if="[[_equal(_descriptorType,'classes')]]" restamp="true">
+      <iron-doc-class descriptor="[[_currentDescriptor]]"></iron-doc-class>
     </template>
   </template>
 
@@ -175,6 +179,9 @@ property.
           } else if (descriptorType === 'elements') {
             this._currentDescriptor = namespace.elements &&
                 namespace.elements.filter((e) => (e.name || e.tagname) === name)[0];
+          } else if (descriptorType === 'classes') {
+            this._currentDescriptor = namespace.classes &&
+                namespace.classes.filter((e) => (e.name || e.tagname) === name)[0];
           } else if (descriptorType === 'mixins') {
             this._currentDescriptor = namespace.mixins &&
                 namespace.mixins.filter((m) => m.name === name)[0];


### PR DESCRIPTION
A stripped down version of `<iron-doc-element>`.

One step towards https://github.com/PolymerElements/iron-doc-viewer/issues/122. Also needed for getting these new components working on Polymer core 1.x, where everything interesting is in the Polymer.Base class.