### PR TITLE
Features needed for parity with hydrolysis 1.0 Polymer docs site.

### DIFF
--- a/iron-doc-behavior.html
+++ b/iron-doc-behavior.html
@@ -6,7 +6,7 @@
 
       properties: {
         /**
-         * The [Hydrolysis](https://github.com/PolymerLabs/hydrolysis)-generated
+         * The [Polymer Analyzer](https://github.com/Polymer/polymer-analyzer)-generated
          * element descriptor to display details for.
          *
          * Alternatively, the element descriptor can be provided as JSON via the text content
@@ -106,11 +106,13 @@
       },
 
       _noneToShow: function(showProtected, showInherited, descriptor, name) {
-        var items = descriptor[name];
+        const items = (name === 'behaviors'
+          ? this._getPolymerBehaviors(descriptor)
+          : descriptor[name]);
         if (!items) {
           return true;
         }
-        var filteredItems = this._filterMembers(items, showProtected, showInherited);
+        const filteredItems = this._filterMembers(items, showProtected, showInherited);
         return filteredItems.length === 0;
       },
 
@@ -177,6 +179,10 @@
 
       _getElementId: function(element) {
         return element.name || element.tagname;
+      },
+
+      _getPolymerBehaviors: function(descriptor) {
+        return (((descriptor || {}).metadata || {}).polymer || {}).behaviors || [];
       },
 
       /**

--- a/iron-doc-behavior.html
+++ b/iron-doc-behavior.html
@@ -193,18 +193,31 @@
         // Elements display as "<tagname> (name)" or "name", while
         // everything else displays as "name".
         if (a.name != b.name) {
-          return (a.name || '').localeCompare(b.name || '');
+          return compareUnderscoresLast(a.name || '', b.name || '');
         }
         if (a.tagname != b.tagname) {
-          return (a.tagname || '').localeCompare(b.tagname || '');
-        }
-        if (a.name != b.name) {
-          return (a.name || '').localeCompare(b.name || '');
+          return compareUnderscoresLast(a.tagname || '', b.tagname || '');
         }
         return 0;
       },
 
     };
+
+    /**
+     * Compare two strings such that more leading underscores sort later.
+     */
+    function compareUnderscoresLast(a, b) {
+      const numA = numLeadingUnderscores(a);
+      const numB = numLeadingUnderscores(b);
+      if (numA !== numB) {
+        return numA - numB;
+      }
+      return a.localeCompare(b);
+    }
+
+    function numLeadingUnderscores(str) {
+      return str.match(/^_*/)[0].length;
+    }
 
   })();
 </script>

--- a/iron-doc-function.html
+++ b/iron-doc-function.html
@@ -17,12 +17,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="iron-doc-function">
   <template>
     <style include="iron-doc-viewer-2-styles"></style>
+    <style>
+      .paramName {
+        margin-right: 10px;
+      }
+    </style>
 
     <div id="transitionMask">
       <div id="signature">
         <a href$="#[[anchorId]]" class="name deeplink">[[descriptor.name]]</a>(<span class="params code"><span>[[_paramText]]</span></span>)<!--
         --><span class="return" hidden$="[[!descriptor.return]]">: <span class="type code">[[descriptor.return.type]]</span></span>
       </div>
+
+      <ul id="params" hidden$="[[_empty(descriptor.params)]]">
+        <template is="dom-repeat"
+                  items="[[descriptor.params]]">
+          <li>
+            <code class="paramName">[[item.name]]</code>
+            <span>[[item.description]]</span>
+          </li>
+        </template>
+      </ul>
+
       <div id="details">
         <div id="meta" hidden$="[[_computeHideMeta(descriptor)]]">
           <span id="type" class="type">[[descriptor.type]]</span>
@@ -151,6 +167,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             annotations.push('notifies');
           }
           return annotations.join(' – ');
+        },
+
+        _empty: function(items) {
+          return !items || !items.length;
         }
       });
     })();

--- a/iron-doc-namespace.html
+++ b/iron-doc-namespace.html
@@ -107,7 +107,7 @@ property.
 
     <section anchor-id$="[[_formatAnchor(prefix,'behaviors')]]" class="card" hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'behaviors')]]">
       <header><a href$="#[[_formatAnchor(prefix,'behaviors')]]" class="deeplink">Behaviors</a></header>
-      <template is="dom-repeat" items="[[descriptor.behaviors]]" sort="_compareDescriptors">
+      <template is="dom-repeat" items="[[_getPolymerBehaviors(descriptor)]]" sort="_compareDescriptors">
         <iron-doc-summary
           name="[[item.name]]"
           description="[[item.summary]]"

--- a/iron-doc-polymer-behavior.html
+++ b/iron-doc-polymer-behavior.html
@@ -1,0 +1,91 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../marked-element/marked-element.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/shadow.html">
+<link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../prism-element/prism-highlighter.html">
+<link rel="import" href="../prism-element/prism-theme-default.html">
+
+<link rel="import" href="iron-doc-behavior.html">
+<link rel="import" href="iron-doc-property-2.html">
+<link rel="import" href="iron-doc-function.html">
+<link rel="import" href="iron-doc-viewer-2-styles.html">
+
+<!--
+Renders documentation describing a Polymer 1.x behavior.
+-->
+
+<dom-module id="iron-doc-polymer-behavior">
+  <template>
+    <style include="iron-doc-viewer-2-styles prism-theme-default"></style>
+
+    <prism-highlighter></prism-highlighter>
+
+    <h1>Behavior [[descriptor.name]]</h1>
+    <p hidden$="[[!descriptor.summary]]">[[descriptor.summary]]</p>
+
+    <div class="metadata">Path: <span class="code">[[descriptor.path]]</span></div>
+
+    <div class="metadata" hidden$="[[!descriptor.mixins]]">Mixins: &#8203;
+      <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareDescriptors">
+        <a class="name deeplink mixin" href$="[[baseHref]]/mixins/[[item]]">[[item]]</a>
+      </template>
+    </div>
+
+    <section id="description" class="card" hidden$="[[!descriptor.description]]">
+      <marked-element sanitize markdown="[[descriptor.description]]">
+        <div slot="markdown-html" class="markdown-html"></div>
+      </marked-element>
+    </section>
+
+    <nav id="api">
+      <header>API Reference</header>
+      <label class="checkbox"><input type="checkbox" checked="{{_showInherited::change}}">Show Inherited</label>
+      <label class="checkbox"><input type="checkbox" checked="{{_showProtected::change}}">Show Protected</label>
+    </nav>
+
+    <section anchor-id$="[[_formatAnchor(prefix,'properties')]]" class="card" hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'properties')]]">
+      <header><a href$="#[[_formatAnchor(prefix,'properties')]]" class="deeplink">Properties</a></header>
+      <div hidden$="[[!descriptor.properties.length]]">
+        <template is="dom-repeat" items="[[_filterMembers(descriptor.properties,_showProtected,_showInherited)]]" sort="_compareDescriptors">
+          <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'property',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+        </template>
+      </div>
+    </section>
+
+    <section anchor-id$="[[_formatAnchor(prefix,'methods')]]" class="card"  hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'methods')]]">
+      <header><a href$="#[[_formatAnchor(prefix,'methods')]]" class="deeplink">Methods</a></header>
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.methods,_showProtected,_showInherited)]]" sort="_compareDescriptors">
+        <iron-doc-function anchor-id$="[[_formatAnchor(prefix,'method',item.name)]]" descriptor="[[item]]"></iron-doc-function>
+      </template>
+    </section>
+
+    <section anchor-id$="[[_formatAnchor(prefix,'events')]]" class="card" hidden$="[[_noneToShow(_showProtected,_showInherited,descriptor,'events')]]">
+      <header><a href$="#[[_formatAnchor(prefix,'events')]]" class="deeplink">Events</a></header>
+      <template is="dom-repeat" items="[[_filterMembers(descriptor.events,_showProtected,_showInherited)]]" sort="_compareDescriptors">
+        <iron-doc-property-2 anchor-id$="[[_formatAnchor(prefix,'event',item.name)]]" descriptor="[[item]]"></iron-doc-property-2>
+      </template>
+    </section>
+
+  </template>
+
+  <script>
+    (function() {
+      Polymer({
+        is: 'iron-doc-polymer-behavior',
+
+        behaviors: [Polymer.IronDocBehavior],
+      });
+    })();
+  </script>
+</dom-module>

--- a/iron-doc-viewer-2.html
+++ b/iron-doc-viewer-2.html
@@ -18,10 +18,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../prism-element/prism-highlighter.html">
 <link rel="import" href="../prism-element/prism-theme-default.html">
 
+<link rel="import" href="iron-doc-behavior.html">
 <link rel="import" href="iron-doc-namespace.html">
 <link rel="import" href="iron-doc-element.html">
 <link rel="import" href="iron-doc-class.html">
 <link rel="import" href="iron-doc-mixin.html">
+<link rel="import" href="iron-doc-polymer-behavior.html">
 
 <!--
 Renders documentation describing an element's API.
@@ -70,6 +72,9 @@ property.
     <template is="dom-if" if="[[_equal(_descriptorType,'mixins')]]" restamp="true">
       <iron-doc-mixin descriptor="[[_currentDescriptor]]"></iron-doc-mixin>
     </template>
+    <template is="dom-if" if="[[_equal(_descriptorType,'behaviors')]]" restamp="true">
+      <iron-doc-polymer-behavior descriptor="[[_currentDescriptor]]"></iron-doc-polymer-behavior>
+    </template>
     <template is="dom-if" if="[[_equal(_descriptorType,'classes')]]" restamp="true">
       <iron-doc-class descriptor="[[_currentDescriptor]]"></iron-doc-class>
     </template>
@@ -80,20 +85,9 @@ property.
       Polymer({
         is: 'iron-doc-viewer-2',
 
-        properties: {
-          /**
-           * The [Polymer Analyzer](https://github.com/Polymer/polymer-analyzer)-generated
-           * element descriptor to display details for.
-           *
-           * Alternatively, the element descriptor can be provided as JSON via the text content
-           * of this element.
-           *
-           * @type {hydrolysis.ElementDescriptor}
-           */
-          descriptor: {
-            type: Object,
-          },
+        behaviors: [Polymer.IronDocBehavior],
 
+        properties: {
           rootNamespace: {
             type: String,
           },
@@ -185,6 +179,9 @@ property.
           } else if (descriptorType === 'mixins') {
             this._currentDescriptor = namespace.mixins &&
                 namespace.mixins.filter((m) => m.name === name)[0];
+          } else if (descriptorType === 'behaviors') {
+            this._currentDescriptor =
+              this._getPolymerBehaviors(namespace).filter((b) => b.name === name)[0];
           } else if (descriptorType === 'functions') {
             this._currentDescriptor = namespace.functions &&
                 namespace.functions.filter((f) => f.name === name)[0];


### PR DESCRIPTION
This should let us launch the new `<iron-doc-*>` components on polymer-project.org, which will let us drop the legacy hydrolysis versions from the 2.0-analyzer branch.

- Add `<iron-doc-polymer-behavior>`. Almost the same as `<iron-doc-mixin>`.
- Sort things with leading underscores last.
- Show function parameter descriptions in a list (screenshot below).

![screen shot 2017-06-02 at 4 53 31 pm](https://cloud.githubusercontent.com/assets/48894/26748692/c93d314c-47b4-11e7-9319-21b4d97a2f0a.png)
