### PR TITLE
Routing changes.

### DIFF
--- a/iron-doc-nav.html
+++ b/iron-doc-nav.html
@@ -82,7 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           baseHref: {
             type: String,
-            value: ''
+            value: '#'
           },
 
           _sections: Array

--- a/iron-doc-nav.html
+++ b/iron-doc-nav.html
@@ -54,7 +54,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <ul>
           <template is="dom-repeat" items="[[section.items]]">
             <li>
-              <a href="#" on-tap="_select" title$="[[item.name]]"
+              <a href="[[baseHref]][[item.path]]"
+                 title$="[[item.name]]"
+                 on-tap="_select"
                  selected$="[[_eq(item.path, path)]]">
                 [[item.name]]
               </a>
@@ -76,9 +78,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             observer: '_descriptorChanged'
           },
 
-          path: {
+          path: String,
+
+          baseHref: {
             type: String,
-            notify: true
+            value: ''
           },
 
           _sections: Array
@@ -97,8 +101,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         },
 
         _select(event) {
-          event.preventDefault();
-          this.path = event.model.item.path;
           this.fire('select');
         },
 

--- a/iron-doc-viewer-behavior.html
+++ b/iron-doc-viewer-behavior.html
@@ -17,7 +17,7 @@
          */
         baseHref: {
           type: String,
-          value: ''
+          value: '#'
         },
 
         /**

--- a/iron-doc-viewer-behavior.html
+++ b/iron-doc-viewer-behavior.html
@@ -129,28 +129,6 @@
         return name;
       },
 
-      _getNamespaceName: function(name) {
-        if (name == null) {
-          return undefined;
-        }
-        var lastDotIndex = name.lastIndexOf('.');
-        if (lastDotIndex === -1) {
-          return undefined;
-        }
-        return name.substring(0, lastDotIndex);
-      },
-
-      _getName: function(name) {
-        if (name == null) {
-          return undefined;
-        }
-        var lastDotIndex = name.lastIndexOf('.');
-        if (lastDotIndex === -1) {
-          return name;
-        }
-        return name.substring(lastDotIndex, name.length);
-      },
-
       _getElementId: function(element) {
         return element.name || element.tagname;
       },

--- a/iron-doc-viewer-behavior.html
+++ b/iron-doc-viewer-behavior.html
@@ -17,7 +17,7 @@
          */
         baseHref: {
           type: String,
-          value: '#'
+          value: ''
         },
 
         /**

--- a/iron-doc-viewer.html
+++ b/iron-doc-viewer.html
@@ -57,9 +57,7 @@ Custom property | Description | Default
   <template>
     <style include="iron-doc-viewer-styles prism-theme-default"></style>
 
-    <template is="dom-if" if="[[!_pathSetExternally]]" restamp>
-      <iron-location path="{{_ourPath}}"></iron-location>
-    </template>
+    <iron-location path="{{_urlPath}}" hash="{{_urlHash}}"></iron-location>
 
     <template is="dom-if" if="[[_equal(_descriptorType,'namespaces')]]" restamp>
       <iron-doc-namespace
@@ -156,22 +154,16 @@ Custom property | Description | Default
 
           _descriptorType: String,
 
-          _pathSetExternally: {
-            type: Boolean,
-            value: false
-          },
+          _urlPath: String,
 
-          _ourPath: String,
-
-          _ourPathChanging: Boolean,
+          _urlHash: String,
 
           _currentDescriptor: Object,
         },
 
         observers: [
-          '_pathChanged(path)',
-          '_ourPathChanged(_ourPath)',
-          '_dataChanged(descriptor, path)'
+          '_routingChanged(baseHref, _urlPath, _urlHash)',
+          '_dataChanged(descriptor, path)',
         ],
 
         _scrollToChanged: function(hash) {
@@ -183,16 +175,22 @@ Custom property | Description | Default
           return a == b;
         },
 
-        _pathChanged: function(path) {
-          this._pathSetExternally = path && !this._ourPathChanging;
-        },
+        _routingChanged: function(baseHref, urlPath, urlHash) {
+          if (baseHref.indexOf('#') === 0) {
+            // URL fragment routing.
+            var parts = (urlHash || '').split('#');
+            this.path = parts[0];
+            this.scrollTo = parts[1];
+            this.fragmentPrefix = parts[0] + '#';
 
-        _ourPathChanged: function(ourPath) {
-          if (ourPath) {
-            // Prevent cycles updating internal/external paths.
-            this._ourPathChanging = true;
-            this.path = ourPath;
-            this._ourPathChanging = false;
+          } else {
+            // URL path routing.
+            if (baseHref && urlPath && urlPath.indexOf(baseHref) === 0) {
+              this.path = urlPath.substring(baseHref.length);
+            } else {
+              this.path = urlPath;
+            }
+            this.scrollTo = urlHash;
           }
         },
 

--- a/iron-doc-viewer.html
+++ b/iron-doc-viewer.html
@@ -19,7 +19,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="iron-doc-element.html">
 <link rel="import" href="iron-doc-mixin.html">
 <link rel="import" href="iron-doc-namespace.html">
-<link rel="import" href="iron-doc-viewer-behavior.html">
 
 <!--
 `iron-doc-viewer` renders documentation about elements, mixins, classes, and
@@ -62,7 +61,7 @@ Custom property | Description | Default
     <template is="dom-if" if="[[_equal(_descriptorType,'namespaces')]]" restamp>
       <iron-doc-namespace
           descriptor="[[_currentDescriptor]]"
-          fragment-prefix="[[fragmentPrefix]]"
+          fragment-prefix="[[_fragmentPrefix]]"
           title="{{title}}"
           scroll-to="[[scrollTo]]"
           base-href="[[baseHref]]">
@@ -72,7 +71,7 @@ Custom property | Description | Default
     <template is="dom-if" if="[[_equal(_descriptorType,'elements')]]" restamp>
       <iron-doc-element
           descriptor="[[_currentDescriptor]]"
-          fragment-prefix="[[fragmentPrefix]]"
+          fragment-prefix="[[_fragmentPrefix]]"
           title="{{title}}"
           scroll-to="[[scrollTo]]"
           base-href="[[baseHref]]">
@@ -82,7 +81,7 @@ Custom property | Description | Default
     <template is="dom-if" if="[[_equal(_descriptorType,'mixins')]]" restamp>
       <iron-doc-mixin
           descriptor="[[_currentDescriptor]]"
-          fragment-prefix="[[fragmentPrefix]]"
+          fragment-prefix="[[_fragmentPrefix]]"
           title="{{title}}"
           scroll-to="[[scrollTo]]"
           base-href="[[baseHref]]">
@@ -92,7 +91,7 @@ Custom property | Description | Default
     <template is="dom-if" if="[[_equal(_descriptorType,'behaviors')]]" restamp>
       <iron-doc-behavior
           descriptor="[[_currentDescriptor]]"
-          fragment-prefix="[[fragmentPrefix]]"
+          fragment-prefix="[[_fragmentPrefix]]"
           title="{{title}}"
           scroll-to="[[scrollTo]]"
           base-href="[[baseHref]]">
@@ -102,7 +101,7 @@ Custom property | Description | Default
     <template is="dom-if" if="[[_equal(_descriptorType,'classes')]]" restamp>
       <iron-doc-class
           descriptor="[[_currentDescriptor]]"
-          fragment-prefix="[[fragmentPrefix]]"
+          fragment-prefix="[[_fragmentPrefix]]"
           title="{{title}}"
           scroll-to="[[scrollTo]]"
           base-href="[[baseHref]]">
@@ -115,9 +114,23 @@ Custom property | Description | Default
       Polymer({
         is: 'iron-doc-viewer',
 
-        behaviors: [Polymer.IronDocViewerBehavior],
-
         properties: {
+          /**
+           * The [Polymer Analyzer](https://github.com/Polymer/polymer-analyzer)-generated
+           * element descriptor to display details for.
+           */
+          descriptor: {
+            type: Object,
+          },
+
+          /**
+           * The base href where this doc viewer is located.
+           */
+          baseHref: {
+            type: String,
+            value: '#'
+          },
+
           /**
            * Path to the item in the descriptor to display.
            *
@@ -159,17 +172,16 @@ Custom property | Description | Default
           _urlHash: String,
 
           _currentDescriptor: Object,
+
+          _fragmentPrefix: String,
+
+          _scrollTo: String
         },
 
         observers: [
           '_routingChanged(baseHref, _urlPath, _urlHash)',
           '_dataChanged(descriptor, path)',
         ],
-
-        _scrollToChanged: function(hash) {
-          // We forward scroll changes to our child components via
-          // data-binding. Nothing to do here in the parent.
-        },
 
         _equal: function(a, b) {
           return a == b;
@@ -180,8 +192,8 @@ Custom property | Description | Default
             // URL fragment routing.
             var parts = (urlHash || '').split('#');
             this.path = parts[0];
-            this.scrollTo = parts[1];
-            this.fragmentPrefix = parts[0] + '#';
+            this._scrollTo = parts[1];
+            this._fragmentPrefix = parts[0] + '#';
 
           } else {
             // URL path routing.
@@ -190,7 +202,7 @@ Custom property | Description | Default
             } else {
               this.path = urlPath;
             }
-            this.scrollTo = urlHash;
+            this._scrollTo = urlHash;
           }
         },
 
@@ -245,8 +257,10 @@ Custom property | Description | Default
             this._currentDescriptor = namespace.mixins &&
                 namespace.mixins.filter((m) => m.name === name)[0];
           } else if (descriptorType === 'behaviors') {
-            this._currentDescriptor =
-              this._getPolymerBehaviors(namespace).filter((b) => b.name === name)[0];
+            var behaviors =
+                ((namespace.metadata || {}).polymer || {}).behaviors;
+            this._currentDescriptor = behaviors &&
+                behaviors.filter((b) => b.name === name)[0];
           } else if (descriptorType === 'functions') {
             this._currentDescriptor = namespace.functions &&
                 namespace.functions.filter((f) => f.name === name)[0];


### PR DESCRIPTION
- iron-doc-viewer now always handles routing. Previously iron-component-page was doing most of the routing work.

- The interesting logic to look at is the `_routingChanged` observer. When `basePath` is `#` (the default), we assume we're doing URL fragment routing, and look for the scroll position after a *second* `#`. This way we can have static routing *and* working anchor link scrolling. Otherwise we use the URL path and fragment as normal.

- Use regular real hyperlinks in iron-nav. Previously it updated a data binding and relied on iron-component-page to update the URL.

- Also some behavior cleanup. iron-doc-viewer didn't really need a bunch of properties that the child elements had, so this cleans up its interface.