### PR TITLE
Demo support and some bugfixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Custom property | Description | Default
 `--iron-doc-font-code` | Mixin applied to code snippets. | `{}`
 `--iron-doc-font-body` | Mixin applied to non-code text. | `{}`
 `--iron-doc-title` | Mixin applied to titles. | `{}`
+`--iron-doc-docs` | Mixin applied to each doc view, except for demos. | `{}`
 
 ### Previous versions
 

--- a/default-theme.html
+++ b/default-theme.html
@@ -23,6 +23,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           @apply --paper-font-code1;
         };
 
+        --iron-doc-docs: {
+          max-width: 56em;
+          margin: 20px;
+        };
+
         --iron-doc-accent-color1: var(--paper-pink-500);
         --iron-doc-accent-color2: var(--paper-indigo-a400);
       }

--- a/iron-doc-behavior.html
+++ b/iron-doc-behavior.html
@@ -26,7 +26,11 @@ JSON descriptor output by
 
 <dom-module id="iron-doc-behavior">
   <template>
-    <style include="iron-doc-viewer-styles prism-theme-default"></style>
+    <style include="iron-doc-viewer-styles prism-theme-default">
+      :host {
+        @apply --iron-doc-docs;
+      }
+    </style>
 
     <prism-highlighter></prism-highlighter>
 

--- a/iron-doc-class.html
+++ b/iron-doc-class.html
@@ -27,6 +27,10 @@ descriptor output by
 <dom-module id="iron-doc-class">
   <template>
     <style include="iron-doc-viewer-styles prism-theme-default">
+      :host {
+        @apply --iron-doc-docs;
+      }
+
       h1 {
         @apply --iron-doc-title;
       }

--- a/iron-doc-demo.html
+++ b/iron-doc-demo.html
@@ -1,0 +1,59 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+
+<dom-module id="iron-doc-demo">
+  <template>
+    <style>
+      :host {
+        display: flex;
+      }
+
+      h1 {
+        @apply --iron-doc-title;
+      }
+
+      iframe {
+        flex-grow: 1;
+      }
+    </style>
+
+    <h1>[[title]]</h1>
+
+    <iframe src$="[[srcPrefix]][[demo.url]]"></iframe>
+  </template>
+
+  <script>
+    (function() {
+      Polymer({
+        is: 'iron-doc-demo',
+
+        properties: {
+          demo: Object,
+
+          srcPrefix: {
+            type: String,
+            value: ''
+          },
+
+          title: {
+            computed: '_computeTitle(demo)',
+            notify: true
+          }
+        },
+
+        _computeTitle: function(demo) {
+          return 'Demo ' + (demo.description || demo.url);
+        }
+      });
+    })();
+  </script>
+</dom-module>

--- a/iron-doc-element.html
+++ b/iron-doc-element.html
@@ -27,6 +27,10 @@ descriptor output by
 <dom-module id="iron-doc-element">
   <template>
     <style include="iron-doc-viewer-styles prism-theme-default">
+      :host {
+        @apply --iron-doc-docs;
+      }
+
       h1 {
         @apply --iron-doc-title;
       }

--- a/iron-doc-function.html
+++ b/iron-doc-function.html
@@ -37,6 +37,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </li>
       </template>
     </ul>
+
+    <marked-element
+        sanitize markdown="[[descriptor.description]]"
+        hidden$="[[!descriptor.description]]">
+     <div slot="markdown-html" class="markdown-html"></div>
+   </marked-element>
   </template>
 
   <script>

--- a/iron-doc-mixin.html
+++ b/iron-doc-mixin.html
@@ -27,6 +27,10 @@ descriptor output by
 <dom-module id="iron-doc-mixin">
   <template>
     <style include="iron-doc-viewer-styles prism-theme-default">
+      :host {
+        @apply --iron-doc-docs;
+      }
+
       h1 {
         @apply --iron-doc-title;
       }

--- a/iron-doc-namespace.html
+++ b/iron-doc-namespace.html
@@ -26,6 +26,10 @@ JSON descriptor output by
 <dom-module id="iron-doc-namespace">
   <template>
     <style include="iron-doc-viewer-styles prism-theme-default">
+      :host {
+        @apply --iron-doc-docs;
+      }
+
       h1 {
         @apply --iron-doc-title;
       }

--- a/iron-doc-nav.html
+++ b/iron-doc-nav.html
@@ -46,20 +46,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       a[selected] {
         color: var(--iron-doc-accent-color2);
       }
+
+      .demos {
+        padding-left: 20px;
+        white-space: nowrap;
+      }
     </style>
 
     <template is="dom-repeat" items="[[_sections]]" as="section">
       <section>
         <h3>[[section.heading]]</h3>
         <ul>
-          <template is="dom-repeat" items="[[section.items]]">
+          <template is="dom-repeat" items="[[section.items]]" as="section">
             <li>
-              <a href="[[baseHref]][[item.path]]"
-                 title$="[[item.name]]"
+              <a href="[[baseHref]][[section.path]]"
+                 title$="[[section.name]]"
                  on-tap="_select"
-                 selected$="[[_eq(item.path, path)]]">
-                [[item.name]]
+                 selected$="[[_eq(section.path, path)]]">
+                [[section.name]]
               </a>
+
+              <template is="dom-if" if="[[section.demos.length]]">
+                <ul class="demos">
+                  <template is="dom-repeat" items="[[section.demos]]" as="demo">
+                    <li>
+                      <a href="[[baseHref]][[demo.path]]"
+                         title$="[[demo.description]]"
+                         on-tap="_select"
+                         selected$="[[_eq(demo.path, path)]]">
+                        [[demo.description]]
+                      </a>
+                    </li>
+                  </template>
+                </ul>
+              </template>
             </li>
           </template>
         </ul>
@@ -117,7 +137,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (!name) {
             continue;
           }
-          sectionItems.push({name: name, path: pathPrefix + name});
+          var path = pathPrefix + name;
+
+          var demos = [];
+          for (var d = 0; d < (item.demos || []).length; d++) {
+            var demo = item.demos[d];
+            if (!demo.url) {
+              continue;
+            }
+            var demoPath = demo.description
+                ? demo.description.toLowerCase().replace(/\s+/g, '-')
+                : demo.url;
+            demos.push({
+              path: path + '/demos/' + demoPath,
+              description: demo.description || 'Demo'
+            });
+          }
+
+          sectionItems.push({ name: name, path: path, demos: demos});
         }
         sectionItems.sort(function(a, b) {
           return a.name.localeCompare(b.name);

--- a/iron-doc-viewer-behavior.html
+++ b/iron-doc-viewer-behavior.html
@@ -107,14 +107,14 @@
           if (hash.indexOf('#') === 0) {
             hash = hash.substring(1);
           }
-          // Ensure all dom-repeats have rendered. Note that
-          // `Polymer.dom.flush()` is not enough here. We'll find the element,
-          // but it won't scroll into view. Maybe it's in the DOM but doesn't
-          // know where it is on screen yet?
-          this.async(function() {
-            var anchor = this.fragmentPrefix + hash;
-            var element = this.$$('[anchor-id="' + anchor + '"]');
-            if (element) {
+          // Ensure dom-repeats have stamped.
+          Polymer.dom.flush();
+          var anchor = this.fragmentPrefix + hash;
+          var element = this.$$('[anchor-id="' + anchor + '"]');
+          if (element) {
+            // Don't scroll until we've drawn the next frame, otherwise our
+            // element might not know it's final screen position yet.
+            Polymer.RenderStatus.afterNextRender(this, function() {
               element.scrollIntoView();
               // Highlight the section for a moment so we can tell where
               // exactly we were deep-linked.
@@ -122,8 +122,8 @@
               this.async(function() {
                 element.classList.remove('scrolled');
               }, 1000);
-            }
-          });
+            });
+          }
         }
       },
 

--- a/iron-doc-viewer.html
+++ b/iron-doc-viewer.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="iron-doc-behavior.html">
 <link rel="import" href="iron-doc-class.html">
+<link rel="import" href="iron-doc-demo.html">
 <link rel="import" href="iron-doc-element.html">
 <link rel="import" href="iron-doc-mixin.html">
 <link rel="import" href="iron-doc-namespace.html">
@@ -54,9 +55,25 @@ Custom property | Description | Default
 
 <dom-module id="iron-doc-viewer">
   <template>
-    <style include="iron-doc-viewer-styles prism-theme-default"></style>
+    <style include="iron-doc-viewer-styles prism-theme-default">
+      :host {
+        display: flex;
+      }
+
+      iron-doc-demo {
+        flex-grow: 1;
+      }
+    </style>
 
     <iron-location path="{{_urlPath}}" hash="{{_urlHash}}"></iron-location>
+
+    <template is="dom-if" if="[[_equal(_descriptorType,'demos')]]" restamp>
+      <iron-doc-demo
+          demo="[[_demo]]"
+          src-prefix="[[demoSrcPrefix]]"
+          title="{{title}}">
+      </iron-doc-demo>
+    </template>
 
     <template is="dom-if" if="[[_equal(_descriptorType,'namespaces')]]" restamp>
       <iron-doc-namespace
@@ -132,6 +149,11 @@ Custom property | Description | Default
           },
 
           /**
+           * URL prefix for demo iframes.
+           */
+          demoSrcPrefix: String,
+
+          /**
            * Path to the item in the descriptor to display.
            *
            * Examples:
@@ -176,7 +198,9 @@ Custom property | Description | Default
 
           _fragmentPrefix: String,
 
-          _scrollTo: String
+          _scrollTo: String,
+
+          _demo: Object
         },
 
         observers: [
@@ -213,7 +237,7 @@ Custom property | Description | Default
             return;
           }
 
-          var descriptorType, name;
+          var descriptorType, name, demoName;
           if (path) {
             if (this.baseHref && path.indexOf(this.baseHref) >= 0) {
               path = path.substring(this.baseHref.length);
@@ -221,6 +245,9 @@ Custom property | Description | Default
             var parts = path.split('/');
             if (parts.length > 1) {
               [, descriptorType, name] = parts;
+            }
+            if (parts.length > 3 && parts[3] === 'demos') {
+              demoName = parts.slice(4).join('/');
             }
           }
 
@@ -265,6 +292,21 @@ Custom property | Description | Default
           } else if (descriptorType === 'functions') {
             this._currentDescriptor = namespace.functions &&
                 namespace.functions.filter((f) => f.name === name)[0];
+          }
+
+          this._demo = null;
+          if (demoName && this._currentDescriptor &&
+            this._currentDescriptor.demos) {
+            for (var i = 0; i < this._currentDescriptor.demos.length; i++) {
+              var demo = this._currentDescriptor.demos[i];
+              var shortName = demo.description &&
+                  demo.description.toLowerCase().replace(/\s+/g, '-');
+              if (demo.url === demoName || (shortName && shortName === demoName)) {
+                this._demo = demo;
+                this._descriptorType = 'demos';
+                break;
+              }
+            }
           }
         },
       });


### PR DESCRIPTION
- Demos render full size in the main doc viewer.
- Each demo listed by name nested under its parent in the nav menu.
- Demos are identified by normalized short urls, e.g. "/elements/my-element/demos/my-fancy-demo".
- See live @ https://aomarks-test-docs.appspot.com/app-layout.html

Also:
- Scroll afterNextRender to fix bad scrolling offsets.
- Restore function descriptions that accidentally got lost a few commits ago.