### PR TITLE
Fix demo height for Edge 14

### DIFF
--- a/iron-doc-demo.html
+++ b/iron-doc-demo.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       iframe {
         flex-grow: 1;
+        height: 100%;
         border: none;
       }
     </style>


### PR DESCRIPTION
Live demo to reproduce: https://cdn.vaadin.com/vaadin-button/1.0.0/ (using latest version 3.0.3)

Currently in Edge 14 demo iframe is cut:

![image](https://user-images.githubusercontent.com/6059356/29228259-1771041a-7f14-11e7-85ff-6dc04eb13745.png)