### PR TITLE
Add import-path for functions in namespaces

### DIFF
--- a/iron-doc-function.html
+++ b/iron-doc-function.html
@@ -48,6 +48,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       .privacy {
         color: #666;
       }
+
+      .import-path {
+        padding-left: 25px;
+      }
     </style>
 
     <code id="signature">
@@ -74,6 +78,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <p hidden$="[[!descriptor.inheritedFrom]]" class="inheritedFrom">
       Inherited from <code>[[descriptor.inheritedFrom]]</code>
     </p>
+
+    <div class="import-path" hidden$="[[!addImportPath]]">Requires import: <code>[[descriptor.sourceRange.file]]</code></div>
 
     <marked-element
         sanitize markdown="[[descriptor.description]]"
@@ -124,6 +130,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           _showParamList: {
             type: Boolean,
             computed: '_computeShowParamList(descriptor)'
+          },
+
+          addImportPath: {
+            type: Boolean,
+            value: false
           }
         },
 

--- a/iron-doc-namespace.html
+++ b/iron-doc-namespace.html
@@ -111,6 +111,7 @@ JSON descriptor output by
       </h2>
       <template is="dom-repeat" items="[[descriptor.functions]]" sort="_compareDescriptors">
         <iron-doc-function
+            add-import-path
             anchor-id="[[fragmentPrefix]]function-[[item.name]]"
             descriptor="[[item]]">
         </iron-doc-function>


### PR DESCRIPTION
Functions added to the root namespace are not required to be defined in 1 file. Therefore, in https://github.com/Polymer/polymer/issues/4725 the request was to add an explicit mention of which import these functions are required. Therefore, for all functions in a namespace, specify the import path that is required.

A screenshot of how that looks:

![image](https://user-images.githubusercontent.com/5948271/34895282-4ff6300e-f7e5-11e7-86b2-b815ee6642c7.png)

Fixes https://github.com/Polymer/polymer/issues/4725