### PR TITLE
Fix #183, add anchors for top-level exports.

### DIFF
--- a/iron-doc-module.html
+++ b/iron-doc-module.html
@@ -55,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template is="dom-repeat" items="[[descriptor.elements]]" sort="_compareDescriptors">
         <iron-doc-element
             descriptor="[[item]]"
-            anchor-id="[[fragmentPrefix]][[item.name]]"
+            anchor-id$="[[fragmentPrefix]][[item.name]]"
             fragment-prefix="[[fragmentPrefix]][[item.name]]-">
         </iron-doc-element>
       </template>
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template is="dom-repeat" items="[[descriptor.classes]]" sort="_compareDescriptors">
         <iron-doc-class
           descriptor="{{item}}"
-          anchor-id="[[fragmentPrefix]][[item.name]]"
+          anchor-id$="[[fragmentPrefix]][[item.name]]"
           fragment-prefix="[[fragmentPrefix]][[item.name]]-">
         </iron-doc-summary>
       </template>
@@ -77,7 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template is="dom-repeat" items="[[descriptor.mixins]]" sort="_compareDescriptors">
         <iron-doc-mixin
             descriptor="[[item]]"
-            anchor-id="[[fragmentPrefix]][[item.name]]"
+	    anchor-id$="[[fragmentPrefix]][[item.name]]"
             fragment-prefix="[[fragmentPrefix]][[item.name]]-">
         </iron-doc-mixin>
       </template>
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template is="dom-repeat" items="[[_getPolymerBehaviors(descriptor)]]" sort="_compareDescriptors">
         <iron-doc-behavior
           descriptor="[[item]]"
-          anchor-id="[[fragmentPrefix]][[item.name]]"
+          anchor-id$="[[fragmentPrefix]][[item.name]]"
           fragment-prefix="[[fragmentPrefix]][[item.name]]-">
         </iron-doc-summary>
       </template>
@@ -103,7 +103,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </h2>
       <template is="dom-repeat" items="[[descriptor.functions]]" sort="_compareDescriptors">
         <iron-doc-function
-            anchor-id="[[fragmentPrefix]][[item.name]]"
+            anchor-id$="[[fragmentPrefix]][[item.name]]"
             descriptor="[[item]]">
         </iron-doc-function>
       </template>


### PR DESCRIPTION
The scroll is off a little on these anchors for some reason. But they seem to work.
If there's a better fix, please close this PR!